### PR TITLE
chore(dep): bump pcomfortcloud to 0.0.22

### DIFF
--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -6,5 +6,5 @@
     "documentation": "https://github.com/sockless-coding/panasonic_cc/",
     "dependencies": [],
     "codeowners": ["sockless-coding"],
-    "requirements": ["pcomfortcloud==0.0.21"]
+    "requirements": ["pcomfortcloud==0.0.22"]
   }


### PR DESCRIPTION
@lostfields released a new version of `pcomfortcloud` setting the client version to a higher / hardcoded version. 
 
https://github.com/lostfields/python-panasonic-comfort-cloud/releases/tag/v0.0.22

Maybe `panasonic_cc` can be updated to use `v0.0.22` of `pcomfortcloud` until @sockless-coding nice automatic version detection has been finalized and merged / released into it so the HACS distributed version will work again for now?