### PR TITLE
Update climate.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE)
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
 This is a custom component to allow control of Panasonic Comfort Cloud devices in [HomeAssistant](https://home-assistant.io).
 

--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -221,7 +221,7 @@ class PanasonicClimateDevice(ClimateEntity):
         return self._api.device_info
     
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         attrs = {}
         try:
             attrs[ATTR_SWING_LR_MODE] = self.swing_lr_mode


### PR DESCRIPTION
[homeassistant.helpers.entity] Entity climate.airco_office (<class 'custom_components.panasonic_cc.climate.PanasonicClimateDevice'>) implements device_state_attributes. Please report it to the custom component author.