### PR TITLE
Fixed bug with Panasonic API declining requests due to old version

### DIFF
--- a/custom_components/panasonic_cc/pcomfortcloud/constants.py
+++ b/custom_components/panasonic_cc/pcomfortcloud/constants.py
@@ -62,7 +62,7 @@ class NanoeMode(Enum):
 
 DEFAULT_X_APP_VERSION = "1.15.0"
 
-MAX_VERSION_AGE = 5
+MAX_VERSION_AGE = 3
 
 SETTING_TOKEN = "token"
 SETTING_VERSION = "version"


### PR DESCRIPTION
Changing the default value of constant MAX_VERSION_AGE to 3 forces the addon to update the locally stored version name by fetching the App Store API. 

This solves a 401-error ({"message":"New version app has been published","code":4106} ) seen in issue #108 