### PR TITLE
add the value of 6 to AirSwingLR

### DIFF
--- a/custom_components/panasonic_cc/pcomfortcloud/constants.py
+++ b/custom_components/panasonic_cc/pcomfortcloud/constants.py
@@ -27,6 +27,7 @@ class AirSwingLR(Enum):
     Mid = 2
     RightMid = 4
     Right = 0
+    All = 6
 
 class EcoMode(Enum):
     Auto = 0


### PR DESCRIPTION
A CS-MTZ16WKE doesn't have LR swing, but returns 6. So I have added 6 so the device works. Obviously I can keep adding this value, but as I can see others on the internet who have a similar problem, it would make sense.

