### PR TITLE
Update climate entity to use extra_state_attributes for horizontal swing

### DIFF
--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -245,7 +245,7 @@ class PanasonicClimateDevice(ClimateEntity):
         return self._api.device_info
     
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         attrs = {}
         try:
             attrs[ATTR_SWING_LR_MODE] = self.swing_lr_mode


### PR DESCRIPTION
Home Assistant removed support for device_state_attributes in 2022.4 (deprecated in 2021.4) which caused the attributes for horizontal swing to no longer be populated.

Updated to use the replacement property extra_state_attributes

https://www.home-assistant.io/changelogs/core-2022.4/ 

https://github.com/home-assistant/core/pull/47304