### PR TITLE
Replace usage of deprecated constants

### DIFF
--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -5,11 +5,9 @@ import voluptuous as vol
 from typing import Any, Dict, Optional, List
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity, HVACAction, HVACMode
-from homeassistant.components.climate.const import HVAC_MODE_OFF, SUPPORT_PRESET_MODE
 from homeassistant.helpers import config_validation as cv, entity_platform, service
 
-from homeassistant.const import (
-    TEMP_CELSIUS, ATTR_TEMPERATURE)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 
 from . import DOMAIN as PANASONIC_DOMAIN, PANASONIC_DEVICES
 
@@ -96,7 +94,7 @@ class PanasonicClimateDevice(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def target_temperature(self):
@@ -110,7 +108,7 @@ class PanasonicClimateDevice(ClimateEntity):
     def hvac_mode(self):
         """Return the current operation."""
         if not self._api.is_on:
-            return HVAC_MODE_OFF
+            return HVACMode.OFF
         hvac_mode = self._api.hvac_mode
         for key, value in OPERATION_LIST.items():
             if value == hvac_mode:
@@ -123,7 +121,7 @@ class PanasonicClimateDevice(ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set HVAC mode."""
-        if hvac_mode == HVAC_MODE_OFF:
+        if hvac_mode == HVACMode.OFF:
             await self._api.turn_off()
         else:
             await self._api.set_hvac_mode(hvac_mode)
@@ -134,13 +132,13 @@ class PanasonicClimateDevice(ClimateEntity):
             HVACAction.OFF
         hvac_mode = self.hvac_mode
         if (
-            (hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.HEAT_COOL)
-            and (self._api.inside_temperature is None or self._api.target_temperature > self._api.inside_temperature)
+                (hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.HEAT_COOL)
+                and (self._api.inside_temperature is None or self._api.target_temperature > self._api.inside_temperature)
         ):
             return HVACAction.HEATING
         elif (
-            (hvac_mode == HVACMode.COOL or hvac_mode == HVACMode.HEAT_COOL)
-            and (self._api.inside_temperature is None or self._api.target_temperature < self._api.inside_temperature)
+                (hvac_mode == HVACMode.COOL or hvac_mode == HVACMode.HEAT_COOL)
+                and (self._api.inside_temperature is None or self._api.target_temperature < self._api.inside_temperature)
         ):
             return HVACAction.COOLING
         elif hvac_mode == HVACMode.DRY:

--- a/custom_components/panasonic_cc/const.py
+++ b/custom_components/panasonic_cc/const.py
@@ -1,11 +1,7 @@
 """Constants for Panasonic Cloud."""
 from homeassistant.const import CONF_ICON, CONF_NAME, CONF_TYPE
-from homeassistant.components.climate.const import (
-    HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY, HVAC_MODE_OFF,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_FAN_MODE, 
-    SUPPORT_SWING_MODE, SUPPORT_PRESET_MODE,
-    PRESET_ECO, PRESET_NONE, PRESET_BOOST)
+from homeassistant.components.climate import ClimateEntityFeature, HVACMode
+from homeassistant.components.climate.const import (PRESET_ECO, PRESET_NONE, PRESET_BOOST)
 
 ATTR_TARGET_TEMPERATURE = "target_temperature"
 ATTR_INSIDE_TEMPERATURE = "inside_temperature"
@@ -58,10 +54,10 @@ ENERGY_SENSOR_TYPES = {
 }
 
 SUPPORT_FLAGS = (
-    SUPPORT_TARGET_TEMPERATURE |
-    SUPPORT_FAN_MODE |
-    SUPPORT_PRESET_MODE |
-    SUPPORT_SWING_MODE )
+        ClimateEntityFeature.TARGET_TEMPERATURE |
+        ClimateEntityFeature.FAN_MODE |
+        ClimateEntityFeature.PRESET_MODE |
+        ClimateEntityFeature.SWING_MODE )
 
 PRESET_LIST = {
     PRESET_NONE: 'Auto',
@@ -70,10 +66,10 @@ PRESET_LIST = {
 }
 
 OPERATION_LIST = {
-    HVAC_MODE_OFF: 'Off',
-    HVAC_MODE_HEAT: 'Heat',
-    HVAC_MODE_COOL: 'Cool',
-    HVAC_MODE_HEAT_COOL: 'Auto',
-    HVAC_MODE_DRY: 'Dry',
-    HVAC_MODE_FAN_ONLY: 'Fan'
-    }
+    HVACMode.OFF: 'Off',
+    HVACMode.HEAT: 'Heat',
+    HVACMode.COOL: 'Cool',
+    HVACMode.HEAT_COOL: 'Auto',
+    HVACMode.DRY: 'Dry',
+    HVACMode.FAN_ONLY: 'Fan'
+}

--- a/custom_components/panasonic_cc/sensor.py
+++ b/custom_components/panasonic_cc/sensor.py
@@ -1,15 +1,13 @@
 """Support for Panasonic sensors."""
 import logging
 
-from homeassistant.const import CONF_ICON, CONF_NAME, TEMP_CELSIUS, CONF_TYPE
+from homeassistant.const import CONF_ICON, CONF_NAME, CONF_TYPE, UnitOfTemperature
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import (
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
     PLATFORM_SCHEMA,
-    STATE_CLASS_TOTAL_INCREASING,
-    STATE_CLASS_MEASUREMENT,
     SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass
 )
 
 from . import DOMAIN as PANASONIC_DOMAIN, PANASONIC_DEVICES
@@ -91,7 +89,7 @@ class PanasonicClimateSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -112,11 +110,11 @@ class PanasonicEnergySensor(SensorEntity):
         self._name = f"{api.name} {self._sensor[CONF_NAME]}"
         self._device_attribute = monitored_state
         if self._device_attribute == ATTR_DAILY_ENERGY:
-            self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
-            self._attr_device_class = DEVICE_CLASS_ENERGY
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_device_class = SensorDeviceClass.ENERGY
         else:
-            self._attr_state_class = STATE_CLASS_MEASUREMENT
-            self._attr_device_class = DEVICE_CLASS_POWER
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+            self._attr_device_class = SensorDeviceClass.POWER
 
     @property
     def unique_id(self):


### PR DESCRIPTION
Magic number constants have been deprecated and will be removed in 2025.1. These deprecations are now causing warnings in Home Assistant logs.

This PR fixes the deprecations by using the new approach

See: https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation