### PR TITLE
Multiple HA Core update requirement fixes and Integration improvements

### DIFF
--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -11,14 +11,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import HomeAssistantType
-
 
 from .const import (
     CONF_FORCE_OUTSIDE_SENSOR, 
     DEFAULT_FORCE_OUTSIDE_SENSOR, 
     CONF_ENABLE_DAILY_ENERGY_SENSOR, 
-    DEFAULT_ENABLE_DAILY_ENERGY_SENSOR)
+    DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
+    PANASONIC_DEVICES,
+    COMPONENT_TYPES)
 
 from .panasonic import PanasonicApiDevice
 
@@ -41,11 +41,6 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-
-
-PANASONIC_DEVICES = "panasonic_devices"
-COMPONENT_TYPES = ["climate", "sensor", "switch"]
-
 def setup(hass, config):
    pass
 
@@ -54,7 +49,7 @@ async def async_setup(hass: HomeAssistant, config: Dict) -> bool:
     hass.data.setdefault(DOMAIN, {})
     return True
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Establish connection with Comfort Cloud."""
     from . import pcomfortcloud
     

--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -89,12 +89,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
-    await asyncio.wait(
-        [
-            hass.config_entries.async_forward_entry_unload(config_entry, component)
-            for component in COMPONENT_TYPES
-        ]
-    )
+    tasks = []
+    for component in COMPONENT_TYPES:
+        tasks.append(
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_unload(config_entry, component)  # noqa: E501
+            )
+        )
+        
+    await asyncio.wait(tasks)
     hass.data.pop(PANASONIC_DEVICES)
     return True
 

--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -61,9 +61,9 @@ class PanasonicClimateDevice(ClimateEntity):
 
     def __init__(self, api):
         """Initialize the climate device."""
-
         self._api = api
         self._attr_hvac_action = HVACAction.IDLE
+        self._enable_turn_on_off_backwards_compatibility = False
 
     @property
     def unique_id(self):
@@ -252,4 +252,3 @@ class PanasonicClimateDevice(ClimateEntity):
         except KeyError:
             pass
         return attrs
-

--- a/custom_components/panasonic_cc/const.py
+++ b/custom_components/panasonic_cc/const.py
@@ -41,6 +41,7 @@ SENSOR_TYPES = {
         CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
     },
 }
+
 ENERGY_SENSOR_TYPES = {
     ATTR_DAILY_ENERGY: {
         CONF_NAME: "Daily Energy",
@@ -58,7 +59,10 @@ SUPPORT_FLAGS = (
     ClimateEntityFeature.TARGET_TEMPERATURE |
     ClimateEntityFeature.FAN_MODE |
     ClimateEntityFeature.PRESET_MODE |
-    ClimateEntityFeature.SWING_MODE )
+    ClimateEntityFeature.SWING_MODE | 
+    ClimateEntityFeature.TURN_OFF | 
+    ClimateEntityFeature.TURN_ON
+    )
 
 PRESET_LIST = {
     PRESET_NONE: 'Auto',
@@ -73,4 +77,12 @@ OPERATION_LIST = {
     HVACMode.HEAT_COOL: 'Auto',
     HVACMode.DRY: 'Dry',
     HVACMode.FAN_ONLY: 'Fan'
-    }
+}
+
+PANASONIC_DEVICES = "panasonic_devices"
+
+COMPONENT_TYPES = [
+    "climate", 
+    "sensor", 
+    "switch"
+    ]

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -2,7 +2,7 @@
     "domain": "panasonic_cc",
     "name": "Panasonic Comfort Cloud",
     "after_dependencies": ["http"],
-    "version": "1.0.38",
+    "version": "2024.5.0",
     "config_flow": true,
     "documentation": "https://github.com/sockless-coding/panasonic_cc/",
     "dependencies": [],

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -2,7 +2,7 @@
     "domain": "panasonic_cc",
     "name": "Panasonic Comfort Cloud",
     "after_dependencies": ["http"],
-    "version": "1.0.37",
+    "version": "1.0.38",
     "config_flow": true,
     "documentation": "https://github.com/sockless-coding/panasonic_cc/",
     "dependencies": [],

--- a/custom_components/panasonic_cc/panasonic.py
+++ b/custom_components/panasonic_cc/panasonic.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Optional
 from homeassistant.util import Throttle
 from homeassistant.const import ATTR_TEMPERATURE
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.components.climate.const import ATTR_HVAC_MODE
 
 from .const import PRESET_LIST, OPERATION_LIST
@@ -26,7 +26,7 @@ def api_call_login(func):
 
 class PanasonicApiDevice:
 
-    def __init__(self, hass: HomeAssistantType, api, device, force_outside_sensor, enable_energy_sensor): # noqa: E501
+    def __init__(self, hass: HomeAssistant, api, device, force_outside_sensor, enable_energy_sensor): # noqa: E501
         from .pcomfortcloud import constants
         self.hass = hass
         self._api = api

--- a/custom_components/panasonic_cc/pcomfortcloud/urls.py
+++ b/custom_components/panasonic_cc/pcomfortcloud/urls.py
@@ -20,13 +20,13 @@ def get_groups():
 def status(guid):
     return '{base_url}/deviceStatus/{guid}'.format(
         base_url=BASE_URL,
-        guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+        guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
     )
 
 def statusCache(guid):
     return '{base_url}/deviceStatus/now/{guid}'.format(
         base_url=BASE_URL,
-        guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+        guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
     )
 
 def control():


### PR DESCRIPTION
- Use ClimateEntityFeature.TURN_OFF and ClimateEntityFeature.TURN_ON
- Update manifest version to 2024.5.0
- Remove deprecated HomeAssistantType reference
- Disable _enable_turn_on_off_backwards_compatibility
- Resolve "Passing coroutines is forbidden, use tasks explicitly."
- Resolve regex pattern matching bug