### PR TITLE
Use raw string for regex to avoid SyntaxWarning

### DIFF
--- a/custom_components/panasonic_cc/pcomfortcloud/apiclient.py
+++ b/custom_components/panasonic_cc/pcomfortcloud/apiclient.py
@@ -254,13 +254,13 @@ class ApiClient(panasonicsession.PanasonicSession):
     def _get_device_status_url(self, guid):
         return '{base_url}/deviceStatus/{guid}'.format(
             base_url=constants.BASE_PATH_ACC,
-            guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+            guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
         )
 
     def _get_device_status_now_url(self, guid):
         return '{base_url}/deviceStatus/now/{guid}'.format(
             base_url=constants.BASE_PATH_ACC,
-            guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+            guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
         )
 
     def _get_device_status_control_url(self):


### PR DESCRIPTION
in python 3 strings are considered unicode. the `\%` escape used in the regex is therefore treated as an unicode escape instead of a regex character escape. as this is not a valid unicode escape, python 3.12+ throws an SyntaxWarning.

treating the regex string as a raw string fixes the issue.

fixes https://github.com/sockless-coding/panasonic_cc/issues/206