### PR TITLE
Update energy values when current consumption is 0

### DIFF
--- a/custom_components/panasonic_cc/panasonic.py
+++ b/custom_components/panasonic_cc/panasonic.py
@@ -132,7 +132,7 @@ class PanasonicApiDevice:
         t1 = datetime.now()
         if 'energyConsumption' in data['parameters']:
             c_energy = data['parameters']['energyConsumption']
-            if c_energy:
+            if (c_energy is not None) and (c_energy != -255):
                 if self.last_energy_reading_time is not None:
                     if c_energy != self.last_energy_reading:                
                         d = (t1 - self.last_energy_reading_time).total_seconds() / 60 / 60  # noqa: E501

--- a/custom_components/panasonic_cc/panasonic.py
+++ b/custom_components/panasonic_cc/panasonic.py
@@ -130,26 +130,29 @@ class PanasonicApiDevice:
             _LOGGER.debug("Received no energy data for device {id}".format(**self.device)) # noqa: E501
             return
         t1 = datetime.now()
-        if 'energyConsumption' in data['parameters']:
-            c_energy = data['parameters']['energyConsumption']
-            if (c_energy is not None) and (c_energy != -255):
-                if self.last_energy_reading_time is not None:
-                    if c_energy != self.last_energy_reading:                
-                        d = (t1 - self.last_energy_reading_time).total_seconds() / 60 / 60  # noqa: E501
-                        p = round((c_energy - self.last_energy_reading)*1000 / d)
-                        self.last_energy_reading = c_energy
-                        self.last_energy_reading_time = t1
-                        if p >= 0:
-                            self.current_power_value = p
-                        self.current_power_counter = 0
-                    else:
-                        self.current_power_counter += 1
-                        if self.current_power_counter > 30:
-                            self.current_power_value = 0
-                else:
-                    self.last_energy_reading = c_energy
-                    self.last_energy_reading_time = t1
-                self._daily_energy = data['parameters']['energyConsumption']
+        if 'energyConsumption' not in data['parameters']:
+            return
+        c_energy = data['parameters']['energyConsumption']
+        if (c_energy is None) or (c_energy < 0):
+            return
+            
+        if self.last_energy_reading_time is not None:
+            if c_energy != self.last_energy_reading:                
+                d = (t1 - self.last_energy_reading_time).total_seconds() / 60 / 60  # noqa: E501
+                p = round((c_energy - self.last_energy_reading)*1000 / d)
+                self.last_energy_reading = c_energy
+                self.last_energy_reading_time = t1
+                if p >= 0:
+                    self.current_power_value = p
+                self.current_power_counter = 0
+            else:
+                self.current_power_counter += 1
+                if self.current_power_counter > 30:
+                    self.current_power_value = 0
+        else:
+            self.last_energy_reading = c_energy
+            self.last_energy_reading_time = t1
+        self._daily_energy = data['parameters']['energyConsumption']
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
When "consumption" is zero, the if-clause is not true and as such the currentPower value never set back to zero. some Panasonic HVACs (f.e. S-50PY3E) report 0 W consumption when being "off", whereas most report some base power load (f.e. CS-Z25ZKEW reports 8W minumum)

Partially fixes https://github.com/sockless-coding/panasonic_cc/issues/208