### PR TITLE
Fix HVAC modes missing the friendly name and having an extra °C appended

### DIFF
--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -40,8 +40,6 @@ class PanasonicClimateEntityDescription(ClimateEntityDescription):
 PANASONIC_CLIMATE_DESCRIPTION = PanasonicClimateEntityDescription(
     key="climate",
     translation_key="climate",
-    unit_of_measurement=UnitOfTemperature.CELSIUS,
-    
 )
 
 def convert_operation_mode_to_hvac_mode(operation_mode: constants.OperationMode) -> HVACMode | None:


### PR DESCRIPTION
With the `unit_of_measurement=UnitOfTemperature.CELSIUS` constructor parameter set, the current state and the `hvac_mode` selection of the HVAC device is not rendered properly in the frontend:
- hvac_mode is showing the raw message instead of the friendly name
- an errornous `°C` is appended

removing the parameter fixes both:

![image](https://github.com/user-attachments/assets/3bd9e0d1-1c67-48e0-a0d8-806f62d2a745)
