### PR TITLE
Fixed issue with timezone and energy readings

### DIFF
--- a/custom_components/panasonic_cc/pcomfortcloud/apiclient.py
+++ b/custom_components/panasonic_cc/pcomfortcloud/apiclient.py
@@ -18,16 +18,20 @@ from .panasonicdevice import PanasonicDevice, PanasonicDeviceInfo, PanasonicDevi
 _LOGGER = logging.getLogger(__name__)
 
 _current_time_zone = None
+_current_time_zone_date = None
+
 def get_current_time_zone():
     global _current_time_zone
-    if _current_time_zone is not None:
+    today_date = datetime.now().date()
+    if _current_time_zone is not None and today_date == _current_time_zone_date:
         return _current_time_zone
     local_offset_seconds = -time.timezone
-    if time.daylight:
+    if time.localtime().tm_isdst:
         local_offset_seconds += 3600
     hours, remainder = divmod(abs(local_offset_seconds), 3600)
     minutes = remainder // 60
     _current_time_zone = f"{'+' if local_offset_seconds >= 0 else '-'}{int(hours):02}:{int(minutes):02}"
+    _current_time_zone_date = today_date
     return _current_time_zone
     
 


### PR DESCRIPTION
Incorrect daylight savings check caused the wrong timezone to be sent in the energy request