### PR TITLE
Fix for getting stuck in heat_8_15 preset

### DIFF
--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -291,6 +291,8 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
 
     async def _async_enter_summer_house_mode(self, builder: ChangeRequestBuilder):
         """Enter summer house mode."""
+        if self.coordinator.device.in_summer_house_mode:
+            return
         device = self.coordinator.device
         stored_data = await self.coordinator.async_get_stored_data()
 

--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -291,16 +291,15 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
 
     async def _async_enter_summer_house_mode(self, builder: ChangeRequestBuilder):
         """Enter summer house mode."""
-        if self.coordinator.device.in_summer_house_mode:
-            return
         device = self.coordinator.device
-        stored_data = await self.coordinator.async_get_stored_data()
 
-        stored_data['mode'] = device.parameters.mode.value
-        stored_data['ecoMode'] = device.parameters.eco_mode.value
-        stored_data['targetTemperature'] = device.parameters.target_temperature
-        stored_data['fanSpeed'] = device.parameters.fan_speed.value
-        await self.coordinator.async_store_data(stored_data)
+        if not self.coordinator.device.in_summer_house_mode:
+            stored_data = await self.coordinator.async_get_stored_data()
+            stored_data['mode'] = device.parameters.mode.value
+            stored_data['ecoMode'] = device.parameters.eco_mode.value
+            stored_data['targetTemperature'] = device.parameters.target_temperature
+            stored_data['fanSpeed'] = device.parameters.fan_speed.value
+            await self.coordinator.async_store_data(stored_data)
 
         builder.set_hvac_mode(constants.OperationMode.Heat)
         builder.set_eco_mode(constants.EcoMode.Powerful)

--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -293,7 +293,7 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
         """Enter summer house mode."""
         device = self.coordinator.device
 
-        if not self.coordinator.device.in_summer_house_mode:
+        if not device.in_summer_house_mode:
             stored_data = await self.coordinator.async_get_stored_data()
             stored_data['mode'] = device.parameters.mode.value
             stored_data['ecoMode'] = device.parameters.eco_mode.value


### PR DESCRIPTION
Fixes multiple calls to _async_enter_summer_house_mode overwriting stored_data
Fixes issue #368

Not well tested yet but I'm currently testing it and it **should** work based on my previous change which did work.

There might be an even better fix though (maybe "changing" to a setting which is already the same as the currently active one could/should be blocked even higher up?).

What I have tested for more than two weeks is this:
```
diff --git a/custom_components/panasonic_cc/climate.py b/custom_components/panasonic_cc/climate.py
index 6aae437..6de4688 100644
--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -316,20 +316,11 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
         self._attr_max_temp = 30
         if not self.coordinator.device.in_summer_house_mode:
             return
-        stored_data = await self.coordinator.async_get_stored_data()
-        try:
-            hvac_mode = constants.OperationMode(stored_data['mode']) if 'mode' in stored_data else constants.OperationMode.Heat
-        except:
-            hvac_mode = constants.OperationMode.Heat
-        try:
-            eco_mode = constants.EcoMode(stored_data['ecoMode']) if 'ecoMode' in stored_data else constants.EcoMode.Auto
-        except:
-            eco_mode = constants.EcoMode.Auto
-        target_temperature = stored_data['targetTemperature'] if 'targetTemperature' in stored_data else 20
-        try:
-            fan_speed = constants.FanSpeed(stored_data['fanSpeed']) if 'fanSpeed' in stored_data else constants.FanSpeed.Auto
-        except:
-            fan_speed = constants.FanSpeed.Auto
+        hvac_mode = constants.OperationMode.Heat
+        eco_mode = constants.EcoMode.Auto
+        fan_speed = constants.FanSpeed.Auto
+        target_temperature = 20

         builder.set_hvac_mode(hvac_mode)
         builder.set_eco_mode(eco_mode)
```

That definately works, didn't get stuck in heat_8_15 a single time after this change. But then stored_data is not used at all and temperature and other settings are forced to their defaults instead of previous values when leaving summer_house_mode.