### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -188,7 +188,7 @@ class PanasonicOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize Panasonic options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(
             self, user_input: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
Fix for Config flow that could not be loaded after update to HA 2025.12.

Fixes "Configure" button error: "Config flow could not be loaded: 500 Internal Server Error Server"

Inspired by: https://github.com/rospogrigio/localtuya/commit/59c95cd06c2696afc98f6bc52d5fa060f3c517da