### PR TITLE
This PR fixes the broken authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode/
 .idea/
+.firecrawl/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# Panasonic Comfort Cloud - HomeAssistant Component
+# Panasonic Comfort Cloud for Home Assistant
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 [![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&style=for-the-badge&logo=home-assistant&label=usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.panasonic_cc.total)](https://analytics.home-assistant.io/)
 
-This is a custom component to allow control of Panasonic Comfort Cloud devices in [HomeAssistant](https://home-assistant.io).
+Custom Home Assistant integration for Panasonic Comfort Cloud air conditioners, heat pumps, and supported Aquarea devices.
 
 > [!IMPORTANT]
-> Before installing this integration, please ensure the following steps have been completed in the Panasonic Comfort Cloud App:
+> Panasonic changed its authentication flow. Direct Panasonic ID and password login is no longer reliable for this integration.
 >
-> - **Set Up Two-Factor Authentication (2FA):** Complete the entire 2FA setup process.  
-> - **Select the SMS Option:** It is crucial to choose the SMS option for 2FA. Failing to do so will result in the error “Missing required parameter: code.”  
+> The recommended setup is:
+> 1. Generate a Panasonic OAuth `refresh_token` with the included helper script.
+> 2. Paste that token into the integration config flow in Home Assistant.
 >
-> For optimal operation, it is also recommended that you use separate accounts for Home Assistant and the Comfort Cloud App.
+> Username and password fields remain available as fallback fields, but the refresh token is the primary authentication method now.
 
 <p>
     <img src="https://github.com/sockless-coding/panasonic_cc/raw/master/doc/controls.png" alt="Example controls" style="vertical-align: top;max-width:100%" align="top" />
@@ -21,58 +22,101 @@ This is a custom component to allow control of Panasonic Comfort Cloud devices i
     <img src="https://github.com/sockless-coding/panasonic_cc/raw/master/doc/diagnostics.png" alt="Example diagnostics" style="vertical-align: top;max-width:100%" align="top" />
 </p>
 
-
-
 ## Features
 
-* Climate component for Panasonic airconditioners and heatpumps
-* Horizontal swing mode selection
-* Sensors for inside and outside temperature (where available)
-* Switch for toggling Nanoe mode (where available)
-* Switch for toggling ECONAVI mode (where available)
-* Switch for toggling AI ECO mode (where available)
-* Daily energy sensor (optional)
-* Current Power sensor (Calculated from energy reading)
-* Zone controls (where available)
+- Climate entities for Panasonic air conditioners and heat pumps
+- Horizontal swing mode selection
+- Sensors for inside and outside temperature where available
+- Nanoe, ECONAVI, and AI ECO switches where available
+- Optional daily energy sensors
+- Calculated current power sensor from energy readings
+- Zone controls where available
+- Aquarea support for compatible devices
 
 ## Installation
 
-### HACS (recommended)
-1. [Install HACS](https://hacs.xyz/docs/setup/download), if you did not already
-2. [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sockless-coding&repository=panasonic_cc&category=integration)
-3. Press the Download button
-4. Restart Home Assistant
-5. [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=panasonic_cc)
+### HACS
 
-### Install manually
-Clone or copy this repository and copy the folder 'custom_components/panasonic_cc' into '<homeassistant config>/custom_components/panasonic_cc'
+1. Install [HACS](https://hacs.xyz/docs/setup/download) if it is not already installed.
+2. Add this repository as a custom integration or open it directly:
+   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sockless-coding&repository=panasonic_cc&category=integration)
+3. Download the integration from HACS.
+4. Restart Home Assistant.
+5. Start the config flow:
+   [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=panasonic_cc)
 
-## Configuration
+### Manual install
 
-Once installed, the Panasonic Comfort Cloud integration can be configured via the Home Assistant integration interface where it will let you enter your Panasonic ID and Password.
+Copy `custom_components/panasonic_cc` into your Home Assistant `custom_components` directory and restart Home Assistant.
+
+## Authentication Setup
+
+### Recommended: refresh token
+
+Generate a Panasonic refresh token once, then use that token in Home Assistant.
+
+1. Prepare a temporary Node/Playwright environment:
+
+```bash
+mkdir -p /tmp/pwprobe
+cd /tmp/pwprobe
+npm init -y
+npm install playwright
+npx playwright install chromium
+```
+
+2. Run the helper script from that directory:
+
+```bash
+cd /tmp/pwprobe
+node /path/to/panasonic_cc/tools/panasonic_oauth_helper.mjs /tmp/panasonic-refresh-token.json
+```
+
+Example for this repository checkout:
+
+```bash
+cd /tmp/pwprobe
+node /Users/Liam/Developer/GitHub/panasonic_cc/tools/panasonic_oauth_helper.mjs /tmp/panasonic-refresh-token.json
+```
+
+3. A Chromium window will open. Complete the Panasonic login manually, including any MFA steps.
+4. When the script reports success, copy the `refresh_token` value from the JSON output.
+5. In Home Assistant, add or reconfigure the Panasonic Comfort Cloud integration and paste the token into the `refresh_token` field.
+
+Use only the `refresh_token`. Do not paste the `access_token` or `id_token` into Home Assistant.
+
+### If the token expires
+
+If Panasonic revokes or expires the refresh token, the integration will stop authenticating. Run the helper again to generate a fresh token, then reconfigure the integration with the new value.
+
+## Home Assistant Configuration
+
+The config flow now accepts:
+
+- `refresh_token`: recommended and preferred
+- `username` and `password`: optional compatibility fields
+- Daily energy and polling options
 
 ![Setup](https://github.com/sockless-coding/panasonic_cc/raw/master/doc/setup.png)
 
-After inital setup, the following options are available:
+After the initial setup, the following options are available:
 
-![Setup](https://github.com/sockless-coding/panasonic_cc/raw/master/doc/configuration.png)
+![Options](https://github.com/sockless-coding/panasonic_cc/raw/master/doc/configuration.png)
 
-## Known issues
+## Known Limitations
 
-- The authentication process can be fiddly and may require resetting the MFA by logging in / out from the Panasonic app.
+- Panasonic's legacy username/password login flow is unreliable due to upstream authentication changes.
+- Refresh tokens are currently the stable authentication path.
+- If the refresh token expires or is revoked, it must be regenerated with the helper script.
 
 ## Dependencies
 
-This integration uses the following modules:
-
-- [`aio-panasonic-comfort-cloud`](https://github.com/sockless-coding/aio-panasonic-comfort-cloud): For Panasonic Heatpumps.
-- [`aioaquarea`](https://github.com/cjaliaga/aioaquarea): For Panasonic Aquarea devices.
-
-
-
+- [`aio-panasonic-comfort-cloud`](https://github.com/sockless-coding/aio-panasonic-comfort-cloud)
+- [`aioaquarea`](https://github.com/cjaliaga/aioaquarea)
 
 ## Support Development
-- :coffee:&nbsp;&nbsp;[Buy me a coffee](https://www.buymeacoffee.com/sockless)
+
+- [Buy me a coffee](https://www.buymeacoffee.com/sockless)
 
 [license-shield]: https://img.shields.io/github/license/sockless-coding/panasonic_cc.svg?style=for-the-badge
 [releases-shield]: https://img.shields.io/github/release/sockless-coding/panasonic_cc.svg?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Custom Home Assistant integration for Panasonic Comfort Cloud air conditioners, 
 > 2. Paste that token into the integration config flow in Home Assistant.
 >
 > Username and password fields remain available as fallback fields, but the refresh token is the primary authentication method now.
+>
+> Panasonic also currently rejects newer advertised app versions on the Comfort Cloud API. This integration therefore pins a known-working Panasonic app version internally.
 
 <p>
     <img src="https://github.com/sockless-coding/panasonic_cc/raw/master/doc/controls.png" alt="Example controls" style="vertical-align: top;max-width:100%" align="top" />
@@ -85,7 +87,9 @@ node /Users/Liam/Developer/GitHub/panasonic_cc/tools/panasonic_oauth_helper.mjs 
 
 Use only the `refresh_token`. Do not paste the `access_token` or `id_token` into Home Assistant.
 
-### If the token expires
+### Token rotation and expiry
+
+Panasonic rotates refresh tokens when they are used. This integration now stores the rotated token back into the Home Assistant config entry automatically.
 
 If Panasonic revokes or expires the refresh token, the integration will stop authenticating. Run the helper again to generate a fresh token, then reconfigure the integration with the new value.
 
@@ -108,6 +112,17 @@ After the initial setup, the following options are available:
 - Panasonic's legacy username/password login flow is unreliable due to upstream authentication changes.
 - Refresh tokens are currently the stable authentication path.
 - If the refresh token expires or is revoked, it must be regenerated with the helper script.
+- Panasonic currently rejects newer advertised app versions for Comfort Cloud API access. This integration pins a known-working app version until Panasonic changes server behavior again.
+
+## Troubleshooting
+
+- If setup fails with `401` and Panasonic error code `4103`, do not assume it literally means you still need to accept terms in the mobile app.
+- Panasonic currently also returns `4103` when the client advertises an app version the service rejects.
+- This integration works around that by pinning a known-working Panasonic app version internally.
+- If authentication breaks again in the future, the most likely causes are:
+  - Panasonic changed the accepted app version again
+  - Panasonic changed the OAuth flow again
+  - Your stored refresh token was rotated, revoked, or expired
 
 ## Dependencies
 

--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -3,7 +3,6 @@ import logging
 from typing import Dict
 
 import asyncio
-from datetime import date
 
 import voluptuous as vol
 
@@ -33,8 +32,8 @@ from .const import (
     ENERGY_COORDINATORS,
     AQUAREA_COORDINATORS,
     CONF_REFRESH_TOKEN,
-    PANASONIC_OAUTH_SCOPE,
-    PANASONIC_CLOUD_WORKING_APP_VERSION)
+    PANASONIC_OAUTH_SCOPE)
+from .panasonic_api import prepare_api_client
 
 from .coordinator import PanasonicDeviceCoordinator, PanasonicDeviceEnergyCoordinator, AquareaDeviceCoordinator
 
@@ -85,9 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     
     client = async_get_clientsession(hass)
     api = ApiClient(username, password, client)
-    await api._settings.is_ready()
-    api._settings._version = PANASONIC_CLOUD_WORKING_APP_VERSION
-    api._settings._versionDate = date.today()
+    await prepare_api_client(api)
     if refresh_token:
         api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
         await api._authentication.refresh_token()

--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -3,6 +3,7 @@ import logging
 from typing import Dict
 
 import asyncio
+from datetime import date
 
 import voluptuous as vol
 
@@ -32,7 +33,8 @@ from .const import (
     ENERGY_COORDINATORS,
     AQUAREA_COORDINATORS,
     CONF_REFRESH_TOKEN,
-    PANASONIC_OAUTH_SCOPE)
+    PANASONIC_OAUTH_SCOPE,
+    PANASONIC_CLOUD_WORKING_APP_VERSION)
 
 from .coordinator import PanasonicDeviceCoordinator, PanasonicDeviceEnergyCoordinator, AquareaDeviceCoordinator
 
@@ -83,10 +85,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     
     client = async_get_clientsession(hass)
     api = ApiClient(username, password, client)
+    await api._settings.is_ready()
+    api._settings._version = PANASONIC_CLOUD_WORKING_APP_VERSION
+    api._settings._versionDate = date.today()
     if refresh_token:
-        await api._settings.is_ready()
         api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
         await api._authentication.refresh_token()
+        if api._settings.refresh_token and api._settings.refresh_token != refresh_token:
+            updated_config = dict(entry.data)
+            updated_config[CONF_REFRESH_TOKEN] = api._settings.refresh_token
+            hass.config_entries.async_update_entry(entry, data=updated_config)
+            conf = updated_config
         await api._authentication._retrieve_client_acc()
         await api._get_groups()
     else:

--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -72,8 +72,6 @@ async def async_setup(hass: HomeAssistant, config: Dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Establish connection with Comfort Cloud."""
-    
-
     conf = entry.data
     if PANASONIC_DEVICES not in hass.data:
         hass.data[PANASONIC_DEVICES] = []
@@ -88,7 +86,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if refresh_token:
         await api._settings.is_ready()
         api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
-    await api.start_session()
+        await api._authentication.refresh_token()
+        await api._authentication._retrieve_client_acc()
+        await api._get_groups()
+    else:
+        await api.start_session()
     devices = api.get_devices()
     
     if CONF_UPDATE_INTERVAL_VERSION not in conf or conf[CONF_UPDATE_INTERVAL_VERSION] < 2:

--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -30,7 +30,9 @@ from .const import (
     STARTUP,
     DATA_COORDINATORS,
     ENERGY_COORDINATORS,
-    AQUAREA_COORDINATORS)
+    AQUAREA_COORDINATORS,
+    CONF_REFRESH_TOKEN,
+    PANASONIC_OAUTH_SCOPE)
 
 from .coordinator import PanasonicDeviceCoordinator, PanasonicDeviceEnergyCoordinator, AquareaDeviceCoordinator
 
@@ -78,10 +80,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]
+    refresh_token = conf.get(CONF_REFRESH_TOKEN)
     enable_daily_energy_sensor = entry.options.get(CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR)
     
     client = async_get_clientsession(hass)
     api = ApiClient(username, password, client)
+    if refresh_token:
+        await api._settings.is_ready()
+        api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
     await api.start_session()
     devices = api.get_devices()
     

--- a/custom_components/panasonic_cc/button.py
+++ b/custom_components/panasonic_cc/button.py
@@ -1,30 +1,13 @@
-from typing import Callable, Awaitable, Any
-from dataclasses import dataclass
 import logging
 
 from homeassistant.core import HomeAssistant
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN, DATA_COORDINATORS, ENERGY_COORDINATORS
 from .coordinator import PanasonicDeviceCoordinator, PanasonicDeviceEnergyCoordinator
 from .base import PanasonicDataEntity
 
 _LOGGER = logging.getLogger(__name__)
-
-@dataclass(frozen=True, kw_only=True)
-class PanasonicButtonEntityDescription(ButtonEntityDescription):
-    """Describes a Panasonic Button entity."""
-    func: Callable[[PanasonicDeviceCoordinator], Awaitable[Any]] | None = None
-
-
-APP_VERSION_DESCRIPTION = PanasonicButtonEntityDescription(
-    key="update_app_version",
-    name="Fetch latest app version",
-    icon="mdi:refresh",
-    entity_category=EntityCategory.DIAGNOSTIC,
-    func = lambda coordinator: coordinator.api_client.update_app_version()
-)
 
 UPDATE_DATA_DESCRIPTION = ButtonEntityDescription(
     key="update_data",
@@ -50,24 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, config, async_add_entities):
         entities.append(CoordinatorUpdateButtonEntity(coordinator, UPDATE_ENERGY_DESCRIPTION))
         
     async_add_entities(entities)
-        
-class PanasonicButtonEntity(PanasonicDataEntity, ButtonEntity):
-    """Representation of a Panasonic Button."""
-    
-    entity_description: PanasonicButtonEntityDescription
-
-    def __init__(self, coordinator: PanasonicDeviceCoordinator, description: PanasonicButtonEntityDescription) -> None:
-        self.entity_description = description
-        super().__init__(coordinator, description.key)
-    
-
-    def _async_update_attrs(self) -> None:
-        """Update the attributes of the entity."""
-
-    async def async_press(self) -> None:
-        """Press the button."""
-        if self.entity_description.func:
-            await self.entity_description.func(self.coordinator)
 
 class CoordinatorUpdateButtonEntity(PanasonicDataEntity, ButtonEntity):
     """Representation of a Coordinator Update Button."""

--- a/custom_components/panasonic_cc/button.py
+++ b/custom_components/panasonic_cc/button.py
@@ -45,7 +45,6 @@ async def async_setup_entry(hass: HomeAssistant, config, async_add_entities):
     energy_coordinators: list[PanasonicDeviceEnergyCoordinator] = hass.data[DOMAIN][ENERGY_COORDINATORS]
 
     for coordinator in data_coordinators:
-        entities.append(PanasonicButtonEntity(coordinator, APP_VERSION_DESCRIPTION))
         entities.append(CoordinatorUpdateButtonEntity(coordinator, UPDATE_DATA_DESCRIPTION))
     for coordinator in energy_coordinators:
         entities.append(CoordinatorUpdateButtonEntity(coordinator, UPDATE_ENERGY_DESCRIPTION))
@@ -84,4 +83,3 @@ class CoordinatorUpdateButtonEntity(PanasonicDataEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Press the button."""
         await self.coordinator.async_request_refresh()
-

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for the Panasonic Comfort Cloud platform."""
 import asyncio
 import logging
+from datetime import date
 from typing import Any, Dict, Optional, Mapping
 
 import voluptuous as vol
@@ -25,9 +26,16 @@ from .const import (
     CONF_FORCE_ENABLE_NANOE,
     DEFAULT_FORCE_ENABLE_NANOE,
     CONF_REFRESH_TOKEN,
-    PANASONIC_OAUTH_SCOPE)
+    PANASONIC_OAUTH_SCOPE,
+    PANASONIC_CLOUD_WORKING_APP_VERSION)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _apply_working_app_version(api: ApiClient) -> None:
+    """Force the last app version known to work with Panasonic's API."""
+    api._settings._version = PANASONIC_CLOUD_WORKING_APP_VERSION
+    api._settings._versionDate = date.today()
 
 
 class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
@@ -110,8 +118,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         try:
             client = async_get_clientsession(self.hass)
             api = ApiClient(username, password, client)
+            await api._settings.is_ready()
+            _apply_working_app_version(api)
             if refresh_token:
-                await api._settings.is_ready()
                 api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
                 await api._authentication.refresh_token()
                 await api._authentication._retrieve_client_acc()
@@ -237,9 +246,10 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         if errors:
             return errors
         api = ApiClient(username, password, client)
+        await api._settings.is_ready()
+        _apply_working_app_version(api)
         try:
             if refresh_token:
-                await api._settings.is_ready()
                 api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
                 await api._authentication.refresh_token()
                 await api._authentication._retrieve_client_acc()

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for the Panasonic Comfort Cloud platform."""
 import asyncio
 import logging
-from datetime import date
 from typing import Any, Dict, Optional, Mapping
 
 import voluptuous as vol
@@ -26,16 +25,10 @@ from .const import (
     CONF_FORCE_ENABLE_NANOE,
     DEFAULT_FORCE_ENABLE_NANOE,
     CONF_REFRESH_TOKEN,
-    PANASONIC_OAUTH_SCOPE,
-    PANASONIC_CLOUD_WORKING_APP_VERSION)
+    PANASONIC_OAUTH_SCOPE)
+from .panasonic_api import prepare_api_client
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _apply_working_app_version(api: ApiClient) -> None:
-    """Force the last app version known to work with Panasonic's API."""
-    api._settings._version = PANASONIC_CLOUD_WORKING_APP_VERSION
-    api._settings._versionDate = date.today()
 
 
 class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
@@ -118,8 +111,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         try:
             client = async_get_clientsession(self.hass)
             api = ApiClient(username, password, client)
-            await api._settings.is_ready()
-            _apply_working_app_version(api)
+            await prepare_api_client(api)
             if refresh_token:
                 api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
                 await api._authentication.refresh_token()
@@ -246,8 +238,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         if errors:
             return errors
         api = ApiClient(username, password, client)
-        await api._settings.is_ready()
-        _apply_working_app_version(api)
+        await prepare_api_client(api)
         try:
             if refresh_token:
                 api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -43,6 +43,36 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         """Get the options flow for this handler."""
         return PanasonicOptionsFlowHandler(config_entry)
 
+    @staticmethod
+    def _get_auth_error(err: Exception, using_refresh_token: bool) -> dict[str, str]:
+        err_msg = str(err)
+        if "Terms and/or Policies have been updated" in err_msg or '"code":4103' in err_msg:
+            return {"base": "terms_updated"}
+        if using_refresh_token and (
+            "invalid_grant" in err_msg
+            or "refresh token" in err_msg.lower()
+            or "expired" in err_msg.lower()
+        ):
+            return {"base": "invalid_refresh_token"}
+        if "invalid_user_password" in err_msg:
+            return {"base": "invalid_user_password"}
+        return {"base": "device_fail"}
+
+    @staticmethod
+    def _normalize_auth_input(
+        user_input: Mapping[str, Any] | None,
+    ) -> tuple[str, str, str | None, dict[str, str]]:
+        if user_input is None:
+            return "", "", None, {}
+        username = (user_input.get(CONF_USERNAME) or "").strip()
+        password = user_input.get(CONF_PASSWORD) or ""
+        refresh_token = (user_input.get(CONF_REFRESH_TOKEN) or "").strip() or None
+        if refresh_token:
+            return username, password, refresh_token, {}
+        if username and password:
+            return username, password, None, {}
+        return username, password, None, {"base": "missing_auth"}
+
     async def _create_entry(
         self,
         username: str,
@@ -83,7 +113,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
             if refresh_token:
                 await api._settings.is_ready()
                 api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
-            await api.start_session()
+                await api._authentication.refresh_token()
+                await api._authentication._retrieve_client_acc()
+                await api._get_groups()
+            else:
+                await api.start_session()
             devices = api.get_devices()
 
             if not devices and not api.unknown_devices:
@@ -98,18 +132,21 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
             return self.async_abort(reason="device_fail")
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected error creating device", e)
+            auth_errors = self._get_auth_error(e, refresh_token is not None)
+            if auth_errors.get("base") == "terms_updated":
+                return self.async_abort(reason="terms_updated")
             return self.async_abort(reason="device_fail")
 
         return await self._create_entry(username, password, refresh_token, user_input)
 
     async def async_step_user(self, user_input=None):
         """User initiated config flow."""
-        
+
         if user_input is None:
             return self.async_show_form(
                 step_id="user", data_schema=vol.Schema({
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
+                    vol.Optional(CONF_USERNAME, default=""): str,
+                    vol.Optional(CONF_PASSWORD, default=""): str,
                     vol.Optional(
                         CONF_REFRESH_TOKEN,
                         default="",
@@ -136,23 +173,53 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
                     ): int,
                 })
             )
-        refresh_token = user_input.get(CONF_REFRESH_TOKEN) or None
+        username, password, refresh_token, errors = self._normalize_auth_input(user_input)
+        if errors:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema({
+                    vol.Optional(CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")): str,
+                    vol.Optional(CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")): str,
+                    vol.Optional(CONF_REFRESH_TOKEN, default=user_input.get(CONF_REFRESH_TOKEN, "")): str,
+                    vol.Optional(
+                        CONF_ENABLE_DAILY_ENERGY_SENSOR,
+                        default=user_input.get(CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR),
+                    ): bool,
+                    vol.Optional(
+                        CONF_FORCE_ENABLE_NANOE,
+                        default=user_input.get(CONF_FORCE_ENABLE_NANOE, False),
+                    ): bool,
+                    vol.Optional(
+                        CONF_USE_PANASONIC_PRESET_NAMES,
+                        default=user_input.get(CONF_USE_PANASONIC_PRESET_NAMES, DEFAULT_USE_PANASONIC_PRESET_NAMES),
+                    ): bool,
+                    vol.Optional(
+                        CONF_DEVICE_FETCH_INTERVAL,
+                        default=user_input.get(CONF_DEVICE_FETCH_INTERVAL, DEFAULT_DEVICE_FETCH_INTERVAL),
+                    ): int,
+                    vol.Optional(
+                        CONF_ENERGY_FETCH_INTERVAL,
+                        default=user_input.get(CONF_ENERGY_FETCH_INTERVAL, DEFAULT_ENERGY_FETCH_INTERVAL),
+                    ): int,
+                }),
+                errors=errors,
+            )
         return await self._create_device(
-            user_input[CONF_USERNAME],
-            user_input[CONF_PASSWORD],
+            username,
+            password,
             refresh_token,
             user_input,
         )
 
     async def async_step_import(self, user_input):
         """Import a config entry."""
-        username = user_input.get(CONF_USERNAME)
-        if not username:
+        username, password, refresh_token, errors = self._normalize_auth_input(user_input)
+        if errors:
             return await self.async_step_user()
         return await self._create_device(
             username,
-            user_input[CONF_PASSWORD],
-            user_input.get(CONF_REFRESH_TOKEN) or None,
+            password,
+            refresh_token,
             user_input,
         )
     
@@ -166,15 +233,17 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
     async def async_auth(self, user_input: Mapping[str, Any]) -> dict[str, str]:
         """Reusable Auth Helper."""
         client = async_get_clientsession(self.hass)
-        username = user_input[CONF_USERNAME]
-        password = user_input[CONF_PASSWORD]
-        refresh_token = user_input.get(CONF_REFRESH_TOKEN) or None
+        username, password, refresh_token, errors = self._normalize_auth_input(user_input)
+        if errors:
+            return errors
         api = ApiClient(username, password, client)
         try:
             if refresh_token:
                 await api._settings.is_ready()
                 api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
-                await api.start_session()
+                await api._authentication.refresh_token()
+                await api._authentication._retrieve_client_acc()
+                await api._get_groups()
             else:
                 await api.reauthenticate()
             devices = api.get_devices()
@@ -188,11 +257,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
             _LOGGER.exception("ClientError", ce)
             return {"base": "device_fail"}
         except Exception as e:  # pylint: disable=broad-except
-            err_msg = str(e)
-            if "invalid_user_password" in err_msg:
-                return {"base": "invalid_user_password"}
             _LOGGER.exception("Unexpected error creating device", e)
-            return {"base": "device_fail"}
+            return self._get_auth_error(e, refresh_token is not None)
 
 
         return {}
@@ -206,16 +272,30 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input and not (errors := await self.async_auth(user_input)):
+            username, password, refresh_token, _ = self._normalize_auth_input(user_input)
+            updated_data = dict(self._entry.data)
+            updated_data[CONF_USERNAME] = username
+            updated_data[CONF_PASSWORD] = password
+            if refresh_token:
+                updated_data[CONF_REFRESH_TOKEN] = refresh_token
+            else:
+                updated_data.pop(CONF_REFRESH_TOKEN, None)
             return self.async_update_reload_and_abort(
                 self._entry,
-                data=user_input,
+                data=updated_data,
             )
 
         return self.async_show_form(
             step_id="reconfigure_confirm",
             data_schema=vol.Schema({
-                vol.Required(CONF_USERNAME): str,
-                vol.Required(CONF_PASSWORD): str,
+                vol.Optional(
+                    CONF_USERNAME,
+                    default=self._entry.data.get(CONF_USERNAME, "") if self._entry else "",
+                ): str,
+                vol.Optional(
+                    CONF_PASSWORD,
+                    default=self._entry.data.get(CONF_PASSWORD, "") if self._entry else "",
+                ): str,
                 vol.Optional(
                     CONF_REFRESH_TOKEN,
                     default=self._entry.data.get(CONF_REFRESH_TOKEN, "") if self._entry else "",

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from aio_panasonic_comfort_cloud import ApiClient
 from . import DOMAIN as PANASONIC_DOMAIN
 from .const import (
-    KEY_DOMAIN,
     CONF_FORCE_OUTSIDE_SENSOR,
     CONF_ENABLE_DAILY_ENERGY_SENSOR,
     DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
@@ -24,7 +23,9 @@ from .const import (
     CONF_ENERGY_FETCH_INTERVAL,
     DEFAULT_ENERGY_FETCH_INTERVAL,
     CONF_FORCE_ENABLE_NANOE,
-    DEFAULT_FORCE_ENABLE_NANOE)
+    DEFAULT_FORCE_ENABLE_NANOE,
+    CONF_REFRESH_TOKEN,
+    PANASONIC_OAUTH_SCOPE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,35 +43,52 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         """Get the options flow for this handler."""
         return PanasonicOptionsFlowHandler(config_entry)
 
-    async def _create_entry(self, username, password):
+    async def _create_entry(
+        self,
+        username: str,
+        password: str,
+        refresh_token: str | None = None,
+        user_input: Mapping[str, Any] | None = None,
+    ):
         """Register new entry."""
-        # Check if ip already is registered
         for entry in self._async_current_entries():
-            if entry.data[KEY_DOMAIN] == PANASONIC_DOMAIN:
+            if entry.domain == PANASONIC_DOMAIN:
                 return self.async_abort(reason="already_configured")
 
-        return self.async_create_entry(title="", data={
+        data = {
             CONF_USERNAME: username,
             CONF_PASSWORD: password,
             CONF_FORCE_OUTSIDE_SENSOR: False,
-            CONF_FORCE_ENABLE_NANOE: DEFAULT_FORCE_ENABLE_NANOE,
-            CONF_ENABLE_DAILY_ENERGY_SENSOR: DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
-            CONF_USE_PANASONIC_PRESET_NAMES: DEFAULT_USE_PANASONIC_PRESET_NAMES,
-            CONF_DEVICE_FETCH_INTERVAL: DEFAULT_DEVICE_FETCH_INTERVAL,
-            CONF_ENERGY_FETCH_INTERVAL: DEFAULT_ENERGY_FETCH_INTERVAL,
-        })
+            CONF_FORCE_ENABLE_NANOE: user_input.get(CONF_FORCE_ENABLE_NANOE, DEFAULT_FORCE_ENABLE_NANOE) if user_input else DEFAULT_FORCE_ENABLE_NANOE,
+            CONF_ENABLE_DAILY_ENERGY_SENSOR: user_input.get(CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR) if user_input else DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
+            CONF_USE_PANASONIC_PRESET_NAMES: user_input.get(CONF_USE_PANASONIC_PRESET_NAMES, DEFAULT_USE_PANASONIC_PRESET_NAMES) if user_input else DEFAULT_USE_PANASONIC_PRESET_NAMES,
+            CONF_DEVICE_FETCH_INTERVAL: user_input.get(CONF_DEVICE_FETCH_INTERVAL, DEFAULT_DEVICE_FETCH_INTERVAL) if user_input else DEFAULT_DEVICE_FETCH_INTERVAL,
+            CONF_ENERGY_FETCH_INTERVAL: user_input.get(CONF_ENERGY_FETCH_INTERVAL, DEFAULT_ENERGY_FETCH_INTERVAL) if user_input else DEFAULT_ENERGY_FETCH_INTERVAL,
+        }
+        if refresh_token:
+            data[CONF_REFRESH_TOKEN] = refresh_token
+        return self.async_create_entry(title="", data=data)
 
-    async def _create_device(self, username, password):
+    async def _create_device(
+        self,
+        username: str,
+        password: str,
+        refresh_token: str | None = None,
+        user_input: Mapping[str, Any] | None = None,
+    ):
         """Create device."""
         try:
             client = async_get_clientsession(self.hass)
             api = ApiClient(username, password, client)
+            if refresh_token:
+                await api._settings.is_ready()
+                api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
             await api.start_session()
             devices = api.get_devices()
 
             if not devices and not api.unknown_devices:
                 _LOGGER.debug("No devices found")
-                return self.async_abort(reason="No devices")
+                return self.async_abort(reason="no_devices")
 
         except asyncio.TimeoutError as te:
             _LOGGER.exception("TimeoutError", te)
@@ -82,7 +100,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
             _LOGGER.exception("Unexpected error creating device", e)
             return self.async_abort(reason="device_fail")
 
-        return await self._create_entry(username, password)
+        return await self._create_entry(username, password, refresh_token, user_input)
 
     async def async_step_user(self, user_input=None):
         """User initiated config flow."""
@@ -91,7 +109,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
             return self.async_show_form(
                 step_id="user", data_schema=vol.Schema({
                     vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,                    
+                    vol.Required(CONF_PASSWORD): str,
+                    vol.Optional(
+                        CONF_REFRESH_TOKEN,
+                        default="",
+                    ): str,
                     vol.Optional(
                         CONF_ENABLE_DAILY_ENERGY_SENSOR,
                         default=DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
@@ -114,14 +136,25 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
                     ): int,
                 })
             )
-        return await self._create_device(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+        refresh_token = user_input.get(CONF_REFRESH_TOKEN) or None
+        return await self._create_device(
+            user_input[CONF_USERNAME],
+            user_input[CONF_PASSWORD],
+            refresh_token,
+            user_input,
+        )
 
     async def async_step_import(self, user_input):
         """Import a config entry."""
         username = user_input.get(CONF_USERNAME)
         if not username:
             return await self.async_step_user()
-        return await self._create_device(username, user_input[CONF_PASSWORD])
+        return await self._create_device(
+            username,
+            user_input[CONF_PASSWORD],
+            user_input.get(CONF_REFRESH_TOKEN) or None,
+            user_input,
+        )
     
     async def async_step_reconfigure(
         self, entry_data: Mapping[str, Any]
@@ -135,9 +168,15 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         client = async_get_clientsession(self.hass)
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
+        refresh_token = user_input.get(CONF_REFRESH_TOKEN) or None
         api = ApiClient(username, password, client)
         try:
-            await api.reauthenticate()
+            if refresh_token:
+                await api._settings.is_ready()
+                api._settings.set_token(refresh_token=refresh_token, scope=PANASONIC_OAUTH_SCOPE)
+                await api.start_session()
+            else:
+                await api.reauthenticate()
             devices = api.get_devices()
 
             if not devices and not api.unknown_devices:
@@ -177,6 +216,10 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
             data_schema=vol.Schema({
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
+                vol.Optional(
+                    CONF_REFRESH_TOKEN,
+                    default=self._entry.data.get(CONF_REFRESH_TOKEN, "") if self._entry else "",
+                ): str,
                 }),
             errors=errors,
         )

--- a/custom_components/panasonic_cc/const.py
+++ b/custom_components/panasonic_cc/const.py
@@ -121,3 +121,5 @@ DEFAULT_DEVICE_FETCH_INTERVAL = 120
 DEFAULT_ENERGY_FETCH_INTERVAL = 300
 CONF_FORCE_ENABLE_NANOE = "force_enable_nanoe"
 DEFAULT_FORCE_ENABLE_NANOE = False
+CONF_REFRESH_TOKEN = "refresh_token"
+PANASONIC_OAUTH_SCOPE = "openid offline_access comfortcloud.control a2w.control"

--- a/custom_components/panasonic_cc/const.py
+++ b/custom_components/panasonic_cc/const.py
@@ -123,3 +123,4 @@ CONF_FORCE_ENABLE_NANOE = "force_enable_nanoe"
 DEFAULT_FORCE_ENABLE_NANOE = False
 CONF_REFRESH_TOKEN = "refresh_token"
 PANASONIC_OAUTH_SCOPE = "openid offline_access comfortcloud.control a2w.control"
+PANASONIC_CLOUD_WORKING_APP_VERSION = "4.0.0"

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -2,7 +2,7 @@
     "domain": "panasonic_cc",
     "name": "Panasonic Comfort Cloud",
     "after_dependencies": ["http"],
-    "version": "2025.5.0",
+    "version": "2026.3.0",
     "config_flow": true,
     "documentation": "https://github.com/sockless-coding/panasonic_cc/",
     "dependencies": [],

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -2,7 +2,7 @@
     "domain": "panasonic_cc",
     "name": "Panasonic Comfort Cloud",
     "after_dependencies": ["http"],
-    "version": "2026.3.0",
+    "version": "2026.3.1",
     "config_flow": true,
     "documentation": "https://github.com/sockless-coding/panasonic_cc/",
     "dependencies": [],

--- a/custom_components/panasonic_cc/panasonic_api.py
+++ b/custom_components/panasonic_cc/panasonic_api.py
@@ -1,0 +1,17 @@
+"""Helpers for Panasonic Comfort Cloud API quirks."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from aio_panasonic_comfort_cloud import ApiClient
+
+from .const import PANASONIC_CLOUD_WORKING_APP_VERSION
+
+
+async def prepare_api_client(api: ApiClient) -> None:
+    """Load settings and pin the Panasonic app version that currently works."""
+    await api._settings.is_ready()
+    # Panasonic currently rejects newer advertised app versions with API error 4103.
+    api._settings._version = PANASONIC_CLOUD_WORKING_APP_VERSION
+    api._settings._versionDate = date.today()

--- a/custom_components/panasonic_cc/strings.json
+++ b/custom_components/panasonic_cc/strings.json
@@ -7,6 +7,7 @@
         "data": {
           "username": "Panasonic ID",
           "password": "Password",
+          "refresh_token": "Refresh token (optional)",
           "enable_daily_energy_sensor": "Enable daily energy sensors",
           "force_enable_nanoe": "Enable Nanoe switch for all devices",
           "use_panasonic_preset_names": "Use 'Quiet' and 'Powerful' instead of 'Eco' and 'Boost' Presets",
@@ -19,7 +20,8 @@
         "description": "Enter your Panasonic ID and password to re-authenticate",
         "data": {
           "username": "Panasonic ID",
-          "password": "Password"
+          "password": "Password",
+          "refresh_token": "Refresh token (optional)"
         }
       }
     },

--- a/custom_components/panasonic_cc/strings.json
+++ b/custom_components/panasonic_cc/strings.json
@@ -3,11 +3,11 @@
     "step": {
       "user": {
         "title": "Panasonic Comfort Cloud",
-        "description": "Enter your Panasonic ID and password",
+        "description": "Enter a refresh token to use Panasonic's current OAuth flow. Username and password are optional fallback fields.",
         "data": {
           "username": "Panasonic ID",
           "password": "Password",
-          "refresh_token": "Refresh token (optional)",
+          "refresh_token": "Refresh token",
           "enable_daily_energy_sensor": "Enable daily energy sensors",
           "force_enable_nanoe": "Enable Nanoe switch for all devices",
           "use_panasonic_preset_names": "Use 'Quiet' and 'Powerful' instead of 'Eco' and 'Boost' Presets",
@@ -17,11 +17,11 @@
       },
       "reconfigure_confirm": {
         "title": "Reconfigure Panasonic Comfort Cloud",
-        "description": "Enter your Panasonic ID and password to re-authenticate",
+        "description": "Update the stored Panasonic authentication details. A refresh token is the preferred option.",
         "data": {
           "username": "Panasonic ID",
           "password": "Password",
-          "refresh_token": "Refresh token (optional)"
+          "refresh_token": "Refresh token"
         }
       }
     },
@@ -29,13 +29,17 @@
       "no_devices": "No devices found. Please check your the account and CFC app and try again.",
       "device_timeout": "Timeout connecting to the API.",
       "device_fail": "Unexpected error connecting to the API.",
-      "invalid_user_password": "Invalid Panasonic ID or password."
+      "invalid_user_password": "Invalid Panasonic ID or password.",
+      "invalid_refresh_token": "The stored refresh token is invalid or expired. Generate a new token and try again.",
+      "missing_auth": "Enter either a refresh token or both Panasonic ID and password.",
+      "terms_updated": "Panasonic requires updated terms or policies to be accepted. Sign in via the official app or helper flow, accept the prompts, then try again."
     },
     "abort": {
       "device_timeout": "Timeout connecting to the device.",
       "device_fail": "Unexpected error creating device.",
       "already_configured": "Device is already configured",
-      "reauth_successful": "Re-authentication successful."
+      "reauth_successful": "Re-authentication successful.",
+      "terms_updated": "Panasonic requires updated terms or policies to be accepted before this integration can continue."
     }
   },
   "options": {

--- a/custom_components/panasonic_cc/translations/en.json
+++ b/custom_components/panasonic_cc/translations/en.json
@@ -7,6 +7,7 @@
         "data": {
           "username": "Panasonic ID",
           "password": "Password",
+          "refresh_token": "Refresh token (optional)",
           "enable_daily_energy_sensor": "Enable daily energy sensors",
           "force_enable_nanoe": "Enable Nanoe switch for all devices",
           "use_panasonic_preset_names": "Use 'Quiet' and 'Powerful' instead of 'Eco' and 'Boost' Presets",
@@ -19,7 +20,8 @@
         "description": "Enter your Panasonic ID and password to re-authenticate",
         "data": {
           "username": "Panasonic ID",
-          "password": "Password"
+          "password": "Password",
+          "refresh_token": "Refresh token (optional)"
         }
       }
     },

--- a/custom_components/panasonic_cc/translations/en.json
+++ b/custom_components/panasonic_cc/translations/en.json
@@ -3,11 +3,11 @@
     "step": {
       "user": {
         "title": "Panasonic Comfort Cloud",
-        "description": "Enter your Panasonic ID and password",
+        "description": "Enter a refresh token to use Panasonic's current OAuth flow. Username and password are optional fallback fields.",
         "data": {
           "username": "Panasonic ID",
           "password": "Password",
-          "refresh_token": "Refresh token (optional)",
+          "refresh_token": "Refresh token",
           "enable_daily_energy_sensor": "Enable daily energy sensors",
           "force_enable_nanoe": "Enable Nanoe switch for all devices",
           "use_panasonic_preset_names": "Use 'Quiet' and 'Powerful' instead of 'Eco' and 'Boost' Presets",
@@ -17,11 +17,11 @@
       },
       "reconfigure_confirm": {
         "title": "Reconfigure Panasonic Comfort Cloud",
-        "description": "Enter your Panasonic ID and password to re-authenticate",
+        "description": "Update the stored Panasonic authentication details. A refresh token is the preferred option.",
         "data": {
           "username": "Panasonic ID",
           "password": "Password",
-          "refresh_token": "Refresh token (optional)"
+          "refresh_token": "Refresh token"
         }
       }
     },
@@ -29,13 +29,17 @@
       "no_devices": "No devices found. Please check your the account and CFC app and try again.",
       "device_timeout": "Timeout connecting to the API.",
       "device_fail": "Unexpected error connecting to the API.",
-      "invalid_user_password": "Invalid Panasonic ID or password."
+      "invalid_user_password": "Invalid Panasonic ID or password.",
+      "invalid_refresh_token": "The stored refresh token is invalid or expired. Generate a new token and try again.",
+      "missing_auth": "Enter either a refresh token or both Panasonic ID and password.",
+      "terms_updated": "Panasonic requires updated terms or policies to be accepted. Sign in via the official app or helper flow, accept the prompts, then try again."
     },
     "abort": {
       "device_timeout": "Timeout connecting to the device.",
       "device_fail": "Unexpected error creating device.",
       "already_configured": "Device is already configured",
-      "reauth_successful": "Re-authentication successful."
+      "reauth_successful": "Re-authentication successful.",
+      "terms_updated": "Panasonic requires updated terms or policies to be accepted before this integration can continue."
     }
   },
   "options": {

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "Panasonic Comfort Cloud",
-    "homeassistant": "2024.12.1"
+    "homeassistant": "2024.12.1",
+    "render_readme": true
 }

--- a/info.md
+++ b/info.md
@@ -1,6 +1,6 @@
 # Panasonic Comfort Cloud
 
-This is a custom component to allow control of Panasonic Comfort Cloud devices in [HomeAssistant](https://home-assistant.io).
+Custom Home Assistant integration for Panasonic Comfort Cloud devices.
 
 <p>
     <img src="https://github.com/sockless-coding/panasonic_cc/raw/master/doc/controls.png" alt="Example controls" style="vertical-align: top;max-width:100%" align="top" />
@@ -8,31 +8,21 @@ This is a custom component to allow control of Panasonic Comfort Cloud devices i
     <img src="https://github.com/sockless-coding/panasonic_cc/raw/master/doc/diagnostics.png" alt="Example diagnostics" style="vertical-align: top;max-width:100%" align="top" />
 </p>
 
-## IMPORTANT
-Before installing this integration, you **must** have **completed** the **2FA** process using the Panasonic Comfort Cloud app.
+## Important
 
-# Features:
+Panasonic changed the upstream authentication flow. The recommended setup now uses a Panasonic OAuth `refresh_token` instead of relying on direct Panasonic ID and password login.
 
-* Climate component for Panasonic airconditioners and heatpumps
-* Horizontal swing mode selection
-* Sensors for inside and outside temperature (where available)
-* Switch for toggling Nanoe mode (where available)
-* Switch for toggling ECONAVI mode (where available)
-* Switch for toggling AI ECO mode (where available)
-* Daily energy sensor (optional)
-* Current Power sensor (Calculated from energy reading)
-* Zone controls (where available)
+This repository includes a helper script at `tools/panasonic_oauth_helper.mjs` that opens the Panasonic login page in a browser, captures the OAuth code, and exchanges it for a refresh token.
 
+## Setup summary
 
-# Configuration
+1. Install the integration.
+2. Run the helper script to generate a refresh token.
+3. Add or reconfigure the integration in Home Assistant.
+4. Paste the `refresh_token` into the config flow.
 
-The Panasonic Comfort Cloud integration can be configured via the Home Assistant integration interface where it will let you enter your Panasonic ID and Password.
-
-![Setup](https://github.com/sockless-coding/panasonic_cc/raw/master/doc/setup.png)
-
-After inital setup, the following options are available:
-
-![Setup](https://github.com/sockless-coding/panasonic_cc/raw/master/doc/configuration.png)
+Username and password fields are still available as optional fallback fields, but the refresh token is the preferred authentication method.
 
 #### Support Development
-- :coffee:&nbsp;&nbsp;[Buy me a coffee](https://www.buymeacoffee.com/sockless)
+
+- [Buy me a coffee](https://www.buymeacoffee.com/sockless)

--- a/info.md
+++ b/info.md
@@ -14,6 +14,8 @@ Panasonic changed the upstream authentication flow. The recommended setup now us
 
 This repository includes a helper script at `tools/panasonic_oauth_helper.mjs` that opens the Panasonic login page in a browser, captures the OAuth code, and exchanges it for a refresh token.
 
+Panasonic also currently rejects newer advertised app versions on the Comfort Cloud API. This integration pins a known-working app version internally and persists rotated refresh tokens automatically.
+
 ## Setup summary
 
 1. Install the integration.

--- a/tools/panasonic_auth_probe.py
+++ b/tools/panasonic_auth_probe.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Probe Panasonic Comfort Cloud auth/bootstrap calls with a refresh token."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import ssl
+import sys
+from pathlib import Path
+
+import aiohttp
+import certifi
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "custom_components" / "panasonic_cc"
+INSPECT_ROOT = Path("/tmp/panasonic_cc_inspect")
+
+if INSPECT_ROOT.exists():
+    sys.path.insert(0, str(INSPECT_ROOT))
+
+from aio_panasonic_comfort_cloud import ApiClient  # type: ignore  # noqa: E402
+from aio_panasonic_comfort_cloud.constants import BASE_PATH_ACC  # type: ignore  # noqa: E402
+from aio_panasonic_comfort_cloud.panasonicrequestheader import PanasonicRequestHeader  # type: ignore  # noqa: E402
+
+
+PANASONIC_OAUTH_SCOPE = "openid offline_access comfortcloud.control a2w.control"
+AGREEMENT_TYPES = (1, 2, 3)
+
+
+async def read_json(response: aiohttp.ClientResponse) -> str:
+    text = await response.text()
+    try:
+        parsed = json.loads(text)
+        return json.dumps(parsed, indent=2, sort_keys=True)
+    except json.JSONDecodeError:
+        return text
+
+
+async def post_json(
+    session: aiohttp.ClientSession,
+    url: str,
+    *,
+    headers: dict[str, str],
+    payload: dict,
+) -> tuple[int, str, dict[str, str]]:
+    response = await session.post(url, headers=headers, json=payload)
+    body = await read_json(response)
+    return response.status, body, dict(response.headers)
+
+
+async def get_json(
+    session: aiohttp.ClientSession,
+    url: str,
+    *,
+    headers: dict[str, str],
+) -> tuple[int, str, dict[str, str]]:
+    response = await session.get(url, headers=headers)
+    body = await read_json(response)
+    return response.status, body, dict(response.headers)
+
+
+async def request_json(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    payload: dict | None = None,
+) -> tuple[int, str, dict[str, str]]:
+    response = await session.request(method, url, headers=headers, json=payload)
+    body = await read_json(response)
+    return response.status, body, dict(response.headers)
+
+
+async def print_request(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    payload: dict | None = None,
+) -> tuple[int, dict | None]:
+    status, body, _ = await request_json(
+        session,
+        method,
+        url,
+        headers=headers,
+        payload=payload,
+    )
+    print(f"{method} {url}")
+    print(f"Status: {status}")
+    print(body)
+    print()
+    try:
+        return status, json.loads(body)
+    except json.JSONDecodeError:
+        return status, None
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Probe Panasonic Comfort Cloud auth/bootstrap endpoints.",
+    )
+    parser.add_argument("--username", required=True, help="Panasonic ID")
+    parser.add_argument("--password", default="", help="Panasonic password")
+    parser.add_argument("--refresh-token", required=True, help="Refresh token")
+    args = parser.parse_args()
+
+    timeout = aiohttp.ClientTimeout(total=60)
+    ssl_context = ssl.create_default_context(cafile=certifi.where())
+    connector = aiohttp.TCPConnector(ssl=ssl_context)
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        api = ApiClient(args.username, args.password, session)
+        await api._settings.is_ready()
+        api._settings.set_token(
+            refresh_token=args.refresh_token,
+            scope=PANASONIC_OAUTH_SCOPE,
+        )
+
+        print("== Refresh token ==")
+        await api._authentication.refresh_token()
+        print("Access token refreshed successfully.")
+        print(f"Rotated refresh token: {api._settings.refresh_token}")
+        print(f"Client ID before bootstrap: {api._settings.clientId!r}")
+        print()
+
+        print("== auth/v2/login ==")
+        auth_headers = await PanasonicRequestHeader.get(
+            api._settings,
+            api._app_version,
+            include_client_id=False,
+        )
+        auth_status, auth_body, auth_response_headers = await post_json(
+            session,
+            f"{BASE_PATH_ACC}/auth/v2/login",
+            headers=auth_headers,
+            payload={"language": 0},
+        )
+        print(f"Status: {auth_status}")
+        print(auth_body)
+        if auth_status == 200:
+            try:
+                client_id = json.loads(auth_body)["clientId"]
+                api._settings.clientId = client_id
+                print(f"Stored clientId: {client_id}")
+            except Exception:
+                print("Could not extract clientId from auth/v2/login response.")
+        print()
+
+        print("== initial device/group ==")
+        group_headers = await PanasonicRequestHeader.get(
+            api._settings,
+            api._app_version,
+        )
+        group_status, group_payload = await print_request(
+            session,
+            "GET",
+            f"{BASE_PATH_ACC}/device/group",
+            headers=group_headers,
+        )
+
+        try:
+            login_payload = json.loads(auth_body)
+        except json.JSONDecodeError:
+            login_payload = {}
+
+        language = int(login_payload.get("language", 0) or 0)
+
+        print("== agreement flow ==")
+        for agreement_type in AGREEMENT_TYPES:
+            status_status, status_payload = await print_request(
+                session,
+                "GET",
+                f"{BASE_PATH_ACC}/auth/agreement/status/{agreement_type}",
+                headers=group_headers,
+            )
+            await print_request(
+                session,
+                "GET",
+                f"{BASE_PATH_ACC}/auth/agreement/documents/{language}/{agreement_type}",
+                headers=group_headers,
+            )
+            if status_status == 200 and isinstance(status_payload, dict):
+                if int(status_payload.get("agreementStatus", 0) or 0) != 1:
+                    await print_request(
+                        session,
+                        "PUT",
+                        f"{BASE_PATH_ACC}/auth/agreement/status/",
+                        headers=group_headers,
+                        payload={"agreementStatus": 1, "type": agreement_type},
+                    )
+
+        print("== final device/group ==")
+        final_group_status, final_group_payload = await print_request(
+            session,
+            "GET",
+            f"{BASE_PATH_ACC}/device/group",
+            headers=group_headers,
+        )
+
+        if auth_status != 200 or final_group_status != 200:
+            print("== Summary ==")
+            print("Panasonic is still rejecting part of the bootstrap flow.")
+            return 1
+
+        print("== Summary ==")
+        print("auth/v2/login and device/group both succeeded.")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tools/panasonic_oauth_helper.mjs
+++ b/tools/panasonic_oauth_helper.mjs
@@ -17,11 +17,14 @@ redirect response, exchanges it for tokens, and optionally writes the refresh
 token payload to disk.
 */
 
-const crypto = require("node:crypto");
-const fs = require("node:fs/promises");
-const process = require("node:process");
-const readline = require("node:readline/promises");
-const { chromium } = require("playwright");
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import process from "node:process";
+import readline from "node:readline/promises";
+
+const requireFromCwd = createRequire(`${process.cwd()}/package.json`);
+const { chromium } = requireFromCwd("playwright");
 
 const APP_CLIENT_ID = "Xmy6xIYIitMxngjB2rHvlm6HSDNnaMJx";
 const AUTH0_CLIENT = "eyJuYW1lIjoiYXV0aDAuanMtdWxwIiwidmVyc2lvbiI6IjkuMjMuMiJ9";

--- a/tools/panasonic_oauth_helper.mjs
+++ b/tools/panasonic_oauth_helper.mjs
@@ -27,7 +27,8 @@ const requireFromCwd = createRequire(`${process.cwd()}/package.json`);
 const { chromium } = requireFromCwd("playwright");
 
 const APP_CLIENT_ID = "Xmy6xIYIitMxngjB2rHvlm6HSDNnaMJx";
-const AUTH0_CLIENT = "eyJuYW1lIjoiYXV0aDAuanMtdWxwIiwidmVyc2lvbiI6IjkuMjMuMiJ9";
+const AUTH0_CLIENT =
+  "eyJuYW1lIjoiQXV0aDAuQW5kcm9pZCIsImVudiI6eyJhbmRyb2lkIjoiMzAifSwidmVyc2lvbiI6IjIuOS4zIn0=";
 const REDIRECT_URI =
   "panasonic-iot-cfc://authglb.digital.panasonic.com/android/com.panasonic.ACCsmart/callback";
 const BASE_PATH_AUTH = "https://authglb.digital.panasonic.com";
@@ -42,7 +43,7 @@ function randomString(length) {
     .slice(0, length);
 }
 
-function buildAuthorizeUrl(codeChallenge, state, nonce) {
+function buildAuthorizeUrl(codeChallenge, state) {
   const params = new URLSearchParams({
     scope: PANASONIC_OAUTH_SCOPE,
     audience: `https://digital.panasonic.com/${APP_CLIENT_ID}/api/v1/`,
@@ -52,9 +53,8 @@ function buildAuthorizeUrl(codeChallenge, state, nonce) {
     code_challenge_method: "S256",
     auth0Client: AUTH0_CLIENT,
     client_id: APP_CLIENT_ID,
-    redirect_uri: `${REDIRECT_URI}?lang=en`,
+    redirect_uri: REDIRECT_URI,
     state,
-    nonce,
   });
   return `${BASE_PATH_AUTH}/authorize?${params.toString()}`;
 }
@@ -109,8 +109,7 @@ async function main() {
     .update(codeVerifier)
     .digest("base64url");
   const state = randomString(20);
-  const nonce = randomString(20);
-  const authorizeUrl = buildAuthorizeUrl(codeChallenge, state, nonce);
+  const authorizeUrl = buildAuthorizeUrl(codeChallenge, state);
 
   let authCode;
   const browser = await chromium.launch({ headless: false });

--- a/tools/panasonic_oauth_helper.mjs
+++ b/tools/panasonic_oauth_helper.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/*
+Browser-assisted Panasonic Comfort Cloud OAuth bootstrap.
+
+Usage:
+  cd /tmp/pwprobe && node /Users/Liam/Developer/GitHub/panasonic_cc/tools/panasonic_oauth_helper.mjs
+  cd /tmp/pwprobe && node /Users/Liam/Developer/GitHub/panasonic_cc/tools/panasonic_oauth_helper.mjs /tmp/panasonic-refresh-token.json
+
+Prerequisites:
+  - playwright installed in the current Node environment
+  - Chromium installed via: npx playwright install chromium
+
+The script opens Panasonic's hosted login page in a real browser, waits for you
+to finish the login manually, captures the OAuth authorization code from the
+redirect response, exchanges it for tokens, and optionally writes the refresh
+token payload to disk.
+*/
+
+const crypto = require("node:crypto");
+const fs = require("node:fs/promises");
+const process = require("node:process");
+const readline = require("node:readline/promises");
+const { chromium } = require("playwright");
+
+const APP_CLIENT_ID = "Xmy6xIYIitMxngjB2rHvlm6HSDNnaMJx";
+const AUTH0_CLIENT = "eyJuYW1lIjoiYXV0aDAuanMtdWxwIiwidmVyc2lvbiI6IjkuMjMuMiJ9";
+const REDIRECT_URI =
+  "panasonic-iot-cfc://authglb.digital.panasonic.com/android/com.panasonic.ACCsmart/callback";
+const BASE_PATH_AUTH = "https://authglb.digital.panasonic.com";
+const PANASONIC_OAUTH_SCOPE =
+  "openid offline_access comfortcloud.control a2w.control";
+
+function randomString(length) {
+  return crypto
+    .randomBytes(length * 2)
+    .toString("base64url")
+    .replace(/[^A-Za-z0-9]/g, "")
+    .slice(0, length);
+}
+
+function buildAuthorizeUrl(codeChallenge, state, nonce) {
+  const params = new URLSearchParams({
+    scope: PANASONIC_OAUTH_SCOPE,
+    audience: `https://digital.panasonic.com/${APP_CLIENT_ID}/api/v1/`,
+    protocol: "oauth2",
+    response_type: "code",
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    auth0Client: AUTH0_CLIENT,
+    client_id: APP_CLIENT_ID,
+    redirect_uri: `${REDIRECT_URI}?lang=en`,
+    state,
+    nonce,
+  });
+  return `${BASE_PATH_AUTH}/authorize?${params.toString()}`;
+}
+
+function extractCode(locationHeader) {
+  if (!locationHeader) {
+    return null;
+  }
+  try {
+    const parsed = new URL(locationHeader);
+    return parsed.searchParams.get("code");
+  } catch {
+    return null;
+  }
+}
+
+async function exchangeCodeForToken(code, codeVerifier) {
+  const response = await fetch(`${BASE_PATH_AUTH}/oauth/token`, {
+    method: "POST",
+    headers: {
+      "Auth0-Client": AUTH0_CLIENT,
+      "Content-Type": "application/json",
+      "User-Agent": "okhttp/4.10.0",
+    },
+    body: JSON.stringify({
+      scope: "openid",
+      client_id: APP_CLIENT_ID,
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: codeVerifier,
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`oauth/token failed (${response.status}): ${text}`);
+  }
+  return JSON.parse(text);
+}
+
+async function main() {
+  const outputPath = process.argv[2];
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const codeVerifier = randomString(43);
+  const codeChallenge = crypto
+    .createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url");
+  const state = randomString(20);
+  const nonce = randomString(20);
+  const authorizeUrl = buildAuthorizeUrl(codeChallenge, state, nonce);
+
+  let authCode;
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  page.on("response", async (response) => {
+    const location = response.headers().location;
+    if (!location?.startsWith("panasonic-iot-cfc://")) {
+      return;
+    }
+    const code = extractCode(location);
+    if (code) {
+      authCode = code;
+    }
+  });
+
+  console.log("Opening Panasonic login page in Chromium.");
+  console.log("Complete the login manually in the browser window.");
+  console.log("This script will capture the OAuth code from the final redirect.");
+
+  await page.goto(authorizeUrl, { waitUntil: "domcontentloaded" });
+
+  while (!authCode) {
+    const answer = await rl.question(
+      "Press Enter after you complete login in the browser, or type 'cancel' to abort: ",
+    );
+    if (answer.trim().toLowerCase() === "cancel") {
+      throw new Error("Cancelled.");
+    }
+    await page.waitForTimeout(1000);
+  }
+
+  const tokenResponse = await exchangeCodeForToken(authCode, codeVerifier);
+  const tokenPayload = {
+    refresh_token: tokenResponse.refresh_token,
+    scope: tokenResponse.scope,
+    access_token: tokenResponse.access_token,
+    expires_in: tokenResponse.expires_in,
+    id_token: tokenResponse.id_token,
+  };
+
+  console.log("\nRefresh token captured successfully.\n");
+  console.log(JSON.stringify(tokenPayload, null, 2));
+
+  if (outputPath) {
+    await fs.writeFile(outputPath, JSON.stringify(tokenPayload, null, 2));
+    console.log(`\nSaved token payload to ${outputPath}`);
+  }
+
+  await browser.close();
+  rl.close();
+}
+
+main().catch(async (error) => {
+  console.error(`\nError: ${error.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

This PR fixes Panasonic Comfort Cloud authentication after recent Panasonic-side changes.

The integration now supports refresh-token based authentication as the primary path, persists rotated refresh tokens automatically, and works around Panasonic currently rejecting newer advertised app versions on the Comfort Cloud API. It also updates the config flow and documentation to reflect the current working setup.

## What changed

- Added support for supplying a Panasonic OAuth `refresh_token` in the config flow
- Prefer refresh-token auth while keeping username/password fields for compatibility
- Persist rotated refresh tokens back into the Home Assistant config entry
- Pin the Panasonic app version sent to the Comfort Cloud API to a known-working value (`4.0.0`)
- Centralized the Panasonic API version override in a shared helper
- Removed the diagnostic “fetch latest app version” button, since that can currently break a working setup
- Improved config-flow messaging around invalid refresh tokens and Panasonic `4103` failures
- Updated README, HACS-facing docs, and integration metadata

## Root cause

Panasonic changed both authentication behavior and API acceptance rules.

Two separate issues were involved:

1. Direct Panasonic ID/password auth is no longer reliable for this integration, while refresh-token based auth still works.
2. Panasonic currently rejects requests when the client advertises a newer app version. In testing:
   - `X-APP-VERSION: 4.1.0` returned `401` with code `4103`
   - `X-APP-VERSION: 4.0.0` returned `200` from `device/group`

Although Panasonic returns `4103` with the message `Terms and/or Policies have been updated`, that response is not always a literal terms-acceptance issue. It can also indicate that the advertised app version is being rejected.

## User impact

After this change:
- users can authenticate successfully using a refresh token generated via the helper flow
- the integration survives Panasonic refresh-token rotation
- the setup flow better reflects the current Panasonic auth reality
- docs now explain the actual workaround and troubleshooting path

## Notes

This PR intentionally uses a targeted workaround by pinning a known-working Panasonic app version internally. That should be revisited if Panasonic changes server behavior again or if the upstream client library grows a cleaner supported way to manage accepted app versions.