### PR TITLE
Fix KeyError in config_flow and update aioaquarea version pin

### DIFF
--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -46,7 +46,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         """Register new entry."""
         # Check if ip already is registered
         for entry in self._async_current_entries():
-            if entry.data[KEY_DOMAIN] == PANASONIC_DOMAIN:
+            if entry.data.get(KEY_DOMAIN) == PANASONIC_DOMAIN:
                 return self.async_abort(reason="already_configured")
 
         return self.async_create_entry(title="", data={

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -10,6 +10,6 @@
     "integration_type": "hub",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/sockless-coding/panasonic_cc/issues",
-    "requirements": ["aiohttp","aio-panasonic-comfort-cloud==2025.5.1","aioaquarea==0.7.2"],
+    "requirements": ["aiohttp","aio-panasonic-comfort-cloud==2025.5.1","aioaquarea>=1.0.6"],
     "quality_scale": "silver"
   }


### PR DESCRIPTION
1. config_flow.py line 49: `entry.data[KEY_DOMAIN]` raises KeyError
     when iterating existing config entries that don't have the "domain"
     key. Changed to `entry.data.get(KEY_DOMAIN)` — returns None if
     missing, comparison evaluates to False, loop continues safely.

  2. manifest.json: `aioaquarea==0.7.2` is an exact pin that conflicts
     with home-assistant-aquarea which requires `>=1.0.6`. When both
     integrations are installed, the resolver picks 0.7.2 and both fail.
     Additionally, 0.7.2 is broken against the current Panasonic API
     (`NoneType` error in `__login_production`). Loosened to `>=1.0.6`

 Tested on HA 2026.3.0 with both integrations installed simultaneously.