### PR TITLE
Fix: Config flow options ignored and Options flow 500 error

### DIFF
--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -25,6 +25,9 @@ from .const import (
     DEFAULT_ENERGY_FETCH_INTERVAL,
     DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
     CONF_USE_PANASONIC_PRESET_NAMES,
+    DEFAULT_USE_PANASONIC_PRESET_NAMES,
+    CONF_FORCE_ENABLE_NANOE,
+    DEFAULT_FORCE_ENABLE_NANOE,
     PANASONIC_DEVICES,
     COMPONENT_TYPES,
     STARTUP,
@@ -76,6 +79,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if PANASONIC_DEVICES not in hass.data:
         hass.data[PANASONIC_DEVICES] = []
 
+    # Migrate initial setup options from entry.data to entry.options
+    # so that all consumers can read from entry.options consistently.
+    if not entry.options:
+        hass.config_entries.async_update_entry(
+            entry,
+            options={
+                CONF_ENABLE_DAILY_ENERGY_SENSOR: conf.get(
+                    CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR
+                ),
+                CONF_FORCE_ENABLE_NANOE: conf.get(
+                    CONF_FORCE_ENABLE_NANOE, DEFAULT_FORCE_ENABLE_NANOE
+                ),
+                CONF_USE_PANASONIC_PRESET_NAMES: conf.get(
+                    CONF_USE_PANASONIC_PRESET_NAMES, DEFAULT_USE_PANASONIC_PRESET_NAMES
+                ),
+                CONF_DEVICE_FETCH_INTERVAL: conf.get(
+                    CONF_DEVICE_FETCH_INTERVAL, DEFAULT_DEVICE_FETCH_INTERVAL
+                ),
+                CONF_ENERGY_FETCH_INTERVAL: conf.get(
+                    CONF_ENERGY_FETCH_INTERVAL, DEFAULT_ENERGY_FETCH_INTERVAL
+                ),
+            },
+        )
+        
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]
     enable_daily_energy_sensor = entry.options.get(CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR)

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -42,7 +42,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
         """Get the options flow for this handler."""
         return PanasonicOptionsFlowHandler(config_entry)
 
-    async def _create_entry(self, username, password):
+    async def _create_entry(self, user_input):
         """Register new entry."""
         # Check if ip already is registered
         for entry in self._async_current_entries():
@@ -50,21 +50,21 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
                 return self.async_abort(reason="already_configured")
 
         return self.async_create_entry(title="", data={
-            CONF_USERNAME: username,
-            CONF_PASSWORD: password,
+            CONF_USERNAME: user_input[CONF_USERNAME],
+            CONF_PASSWORD: user_input[CONF_PASSWORD],
             CONF_FORCE_OUTSIDE_SENSOR: False,
-            CONF_FORCE_ENABLE_NANOE: DEFAULT_FORCE_ENABLE_NANOE,
-            CONF_ENABLE_DAILY_ENERGY_SENSOR: DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
-            CONF_USE_PANASONIC_PRESET_NAMES: DEFAULT_USE_PANASONIC_PRESET_NAMES,
-            CONF_DEVICE_FETCH_INTERVAL: DEFAULT_DEVICE_FETCH_INTERVAL,
-            CONF_ENERGY_FETCH_INTERVAL: DEFAULT_ENERGY_FETCH_INTERVAL,
+            CONF_FORCE_ENABLE_NANOE: user_input.get(CONF_FORCE_ENABLE_NANOE, DEFAULT_FORCE_ENABLE_NANOE),
+            CONF_ENABLE_DAILY_ENERGY_SENSOR: user_input.get(CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR),
+            CONF_USE_PANASONIC_PRESET_NAMES: user_input.get(CONF_USE_PANASONIC_PRESET_NAMES, DEFAULT_USE_PANASONIC_PRESET_NAMES),
+            CONF_DEVICE_FETCH_INTERVAL: user_input.get(CONF_DEVICE_FETCH_INTERVAL, DEFAULT_DEVICE_FETCH_INTERVAL),
+            CONF_ENERGY_FETCH_INTERVAL: user_input.get(CONF_ENERGY_FETCH_INTERVAL, DEFAULT_ENERGY_FETCH_INTERVAL),
         })
 
-    async def _create_device(self, username, password):
+    async def _create_device(self, user_input):
         """Create device."""
         try:
             client = async_get_clientsession(self.hass)
-            api = ApiClient(username, password, client)
+            api = ApiClient(user_input[CONF_USERNAME], user_input[CONF_PASSWORD], client)
             await api.start_session()
             devices = api.get_devices()
 
@@ -82,7 +82,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
             _LOGGER.exception("Unexpected error creating device", e)
             return self.async_abort(reason="device_fail")
 
-        return await self._create_entry(username, password)
+        return await self._create_entry(user_input)
 
     async def async_step_user(self, user_input=None):
         """User initiated config flow."""
@@ -114,14 +114,14 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
                     ): int,
                 })
             )
-        return await self._create_device(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+        return await self._create_device(user_input)
 
     async def async_step_import(self, user_input):
         """Import a config entry."""
         username = user_input.get(CONF_USERNAME)
         if not username:
             return await self.async_step_user()
-        return await self._create_device(username, user_input[CONF_PASSWORD])
+        return await self._create_device(user_input)
     
     async def async_step_reconfigure(
         self, entry_data: Mapping[str, Any]
@@ -185,10 +185,6 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
 
 class PanasonicOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle Panasonic options."""
-
-    def __init__(self, config_entry):
-        """Initialize Panasonic options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
             self, user_input: Optional[Dict[str, Any]] = None

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -40,7 +40,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=PANASONIC_DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return PanasonicOptionsFlowHandler(config_entry)
+        return PanasonicOptionsFlowHandler()
 
     async def _create_entry(self, user_input):
         """Register new entry."""


### PR DESCRIPTION
Fixes #403
Fixes #420

Three related bugs preventing user-selected config options (energy sensors, nanoe, preset names, fetch intervals) from being applied.
Bug 1: User input discarded in config flow (config_flow.py)
async_step_user() collects the full user_input dict (including energy sensor, nanoe, preset names, fetch intervals), but passes only username and password to _create_device() → _create_entry(), which hardcodes all other values to their defaults. The user's selections from the setup form are never saved.
Fix: Pass the full user_input dict through _create_device() → _create_entry() so all user-selected values are persisted to entry.data.
Bug 2: entry.data not migrated to entry.options (__init__.py)
The integration's consumers (switch.py, climate.py, coordinator.py, __init__.py) read settings from entry.options, but the initial config flow saves values to entry.data. entry.options is only populated after the Options flow is used. On a fresh install entry.options is empty, so all settings fall back to defaults.
Fix: Added a migration block in async_setup_entry() that populates entry.options from entry.data when entry.options is empty. This runs once on first startup after install, ensuring all consumers read the correct values without needing changes to each individual consumer.
Bug 3: Options flow crashes with 500 error (config_flow.py)
PanasonicOptionsFlowHandler.__init__() sets self.config_entry = config_entry, but newer Home Assistant versions made config_entry a read-only property on OptionsFlow. This raises AttributeError: property 'config_entry' of 'PanasonicOptionsFlowHandler' object has no setter, causing a 500 Internal Server Error when clicking Configure.
Fix: Removed the __init__ method from PanasonicOptionsFlowHandler and removed the config_entry argument from the constructor call in async_get_options_flow(). The base OptionsFlow class already provides self.config_entry automatically.
Testing

Fresh install with energy sensor checkbox ticked → energy sensors created ✓
Fresh install with energy sensor checkbox unticked → no energy sensors ✓
Configure button (Options flow) no longer throws 500 error ✓
Options values correctly migrated from entry.data to entry.options on startup ✓
Existing installs with options already configured → behaviour unchanged ✓

Files changed

custom_components/panasonic_cc/__init__.py
custom_components/panasonic_cc/config_flow.py