### PR TITLE
feat: expand Aquarea device support with sensors, switches, selects, …

### DIFF
--- a/custom_components/panasonic_cc/binary_sensor.py
+++ b/custom_components/panasonic_cc/binary_sensor.py
@@ -1,0 +1,102 @@
+"""Binary sensors for the Aquarea integration."""
+from __future__ import annotations
+
+import logging
+
+import aioaquarea
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+from .base import AquareaDataEntity
+from .coordinator import AquareaDeviceCoordinator
+from .const import DOMAIN, AQUAREA_COORDINATORS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+AQUAREA_STATUS_DESCRIPTION = BinarySensorEntityDescription(
+    key="status",
+    translation_key="status",
+    name="Error Status",
+    device_class=BinarySensorDeviceClass.PROBLEM,
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
+AQUAREA_DEFROST_DESCRIPTION = BinarySensorEntityDescription(
+    key="defrost",
+    translation_key="defrost",
+    name="Defrost",
+    device_class=BinarySensorDeviceClass.RUNNING,
+    icon="mdi:snowflake-off",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up the Aquarea binary sensors."""
+    entities = []
+    aquarea_coordinators: list[AquareaDeviceCoordinator] = hass.data[DOMAIN][AQUAREA_COORDINATORS]
+    for coordinator in aquarea_coordinators:
+        entities.append(AquareaStatusBinarySensor(coordinator, AQUAREA_STATUS_DESCRIPTION))
+        entities.append(AquareaDefrostBinarySensor(coordinator, AQUAREA_DEFROST_DESCRIPTION))
+    async_add_entities(entities)
+
+
+class AquareaStatusBinarySensor(AquareaDataEntity, BinarySensorEntity):
+    """Binary sensor that indicates if the Aquarea device is on error."""
+
+    entity_description: BinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: AquareaDeviceCoordinator,
+        description: BinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        self.entity_description = description
+        super().__init__(coordinator, description.key)
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the binary sensor."""
+        self._attr_is_on = self.coordinator.device.is_on_error
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return extra state attributes."""
+        if self.coordinator.device.current_error is not None:
+            return {
+                "error_code": self.coordinator.device.current_error.error_code,
+                "error_message": self.coordinator.device.current_error.error_message,
+            }
+        return {}
+
+
+class AquareaDefrostBinarySensor(AquareaDataEntity, BinarySensorEntity):
+    """Binary sensor that indicates if the Aquarea device is in defrost mode."""
+
+    entity_description: BinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: AquareaDeviceCoordinator,
+        description: BinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        self.entity_description = description
+        super().__init__(coordinator, description.key)
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the binary sensor."""
+        is_defrosting = self.coordinator.device.device_mode_status is aioaquarea.DeviceModeStatus.DEFROST
+        self._attr_is_on = is_defrosting
+        self._attr_icon = "mdi:snowflake-melt" if is_defrosting else "mdi:snowflake-off"

--- a/custom_components/panasonic_cc/button.py
+++ b/custom_components/panasonic_cc/button.py
@@ -4,12 +4,14 @@ import logging
 from typing import Any, Awaitable, Callable
 from dataclasses import dataclass
 
+import aioaquarea
+
 from homeassistant.core import HomeAssistant, cached_property
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.entity import DeviceInfo
-from .const import DOMAIN, DATA_COORDINATORS, ENERGY_COORDINATORS
-from .coordinator import PanasonicDeviceCoordinator, PanasonicDeviceEnergyCoordinator
+from .const import DOMAIN, DATA_COORDINATORS, ENERGY_COORDINATORS, AQUAREA_COORDINATORS
+from .coordinator import PanasonicDeviceCoordinator, PanasonicDeviceEnergyCoordinator, AquareaDeviceCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,16 +52,21 @@ async def async_setup_entry(
     entry: Any,
     async_add_entities: Any,
 ) -> None:
-    """Set up the Panasonic button entities."""
+    """Set up the Panasonic and Aquarea button entities."""
     entities = []
     data_coordinators: list[PanasonicDeviceCoordinator] = hass.data[DOMAIN][DATA_COORDINATORS]
     energy_coordinators: list[PanasonicDeviceEnergyCoordinator] = hass.data[DOMAIN][ENERGY_COORDINATORS]
+    aquarea_coordinators: list[AquareaDeviceCoordinator] = hass.data[DOMAIN][AQUAREA_COORDINATORS]
 
     for coordinator in data_coordinators:
         entities.append(PanasonicButtonEntity(coordinator, APP_VERSION_DESCRIPTION))
         entities.append(CoordinatorUpdateButtonEntity(coordinator, UPDATE_DATA_DESCRIPTION))
     for coordinator in energy_coordinators:
         entities.append(CoordinatorUpdateEnergyButtonEntity(coordinator, UPDATE_ENERGY_DESCRIPTION))
+
+    # Aquarea buttons
+    for coordinator in aquarea_coordinators:
+        entities.append(AquareaDefrostButton(coordinator))
 
     async_add_entities(entities)
 
@@ -148,3 +155,36 @@ class CoordinatorUpdateEnergyButtonEntity(ButtonEntity):
     async def async_press(self) -> None:
         """Press the button."""
         await self._coordinator.async_request_refresh()
+
+
+# ---------------------------------------------------------------------------
+# Aquarea buttons
+# ---------------------------------------------------------------------------
+
+class AquareaDefrostButton(ButtonEntity):
+    """Button that requests the Aquarea device to start the defrost process."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the button."""
+        super().__init__()
+        self._coordinator = coordinator
+        self._attr_unique_id = f"{coordinator.device_id}-request_defrost"
+        self._attr_device_info = coordinator.device_info
+        self._attr_translation_key = "request_defrost"
+        self._attr_icon = "mdi:snowflake-melt"
+
+    @cached_property
+    def available(self) -> bool:
+        """Return if the button is available."""
+        return self._coordinator.last_update_success
+
+    async def async_press(self) -> None:
+        """Request to start the defrost process."""
+        _LOGGER.debug(
+            "Requesting defrost for device %s",
+            self._coordinator.device.device_id,
+        )
+        if self._coordinator.device.device_mode_status is not aioaquarea.DeviceModeStatus.DEFROST:
+            await self._coordinator.device.request_defrost()

--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from dataclasses import dataclass
 import logging
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,
@@ -15,7 +16,7 @@ from homeassistant.components.climate import (
 from homeassistant.helpers import config_validation as cv, entity_platform
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
+from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE, PRECISION_WHOLE
 from homeassistant.components.climate.const import ClimateEntityFeature
 
 from .base import PanasonicDataEntity, AquareaDataEntity
@@ -26,6 +27,8 @@ from aioaquarea import (
     OperationStatus as AquareaZoneOperationStatus,
     DeviceAction as AquareaDeviceAction,
     UpdateOperationMode as AquareaUpdateOperationMode,
+    SpecialStatus as AquareaSpecialStatus,
+    DeviceDirection as AquareaDeviceDirection,
 )
 
 from .const import (
@@ -45,6 +48,16 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+AQUAREA_CLIMATE_DELAY_SHORT = 5.0
+AQUAREA_CLIMATE_DELAY_LONG = 10.0
+
+AQUAREA_SPECIAL_STATUS_LOOKUP: dict[str, AquareaSpecialStatus | None] = {
+    PRESET_ECO: AquareaSpecialStatus.ECO,
+    "comfort": AquareaSpecialStatus.COMFORT,
+    PRESET_NONE: None,
+}
+AQUAREA_SPECIAL_STATUS_REVERSE_LOOKUP = {v: k for k, v in AQUAREA_SPECIAL_STATUS_LOOKUP.items()}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -177,6 +190,18 @@ def convert_hvac_mode_to_aquarea_operation_mode(
         case HVACMode.HEAT_COOL:
             return AquareaUpdateOperationMode.AUTO
     return AquareaUpdateOperationMode.OFF
+
+
+def _get_hvac_action_from_device_direction(
+    direction: AquareaDeviceDirection, hvac_mode: HVACMode
+) -> HVACAction:
+    """Convert device direction to HVAC action, using hvac_mode for context."""
+    if direction == AquareaDeviceDirection.PUMP:
+        if hvac_mode == HVACMode.HEAT:
+            return HVACAction.HEATING
+        if hvac_mode == HVACMode.COOL:
+            return HVACAction.COOLING
+    return HVACAction.IDLE
 
 
 async def async_setup_entry(
@@ -511,11 +536,7 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
-    )
+    _attr_precision = PRECISION_WHOLE
     _attr_hvac_mode = HVACMode.OFF
 
     def __init__(
@@ -526,6 +547,25 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
         """Initialize the climate entity."""
         self.entity_description = description
         super().__init__(coordinator, description.key)
+
+        # Set supported features
+        self._attr_supported_features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
+        )
+
+        # Add preset mode support if device supports special status
+        if coordinator.device.support_special_status:
+            self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
+            self._attr_preset_modes = list(AQUAREA_SPECIAL_STATUS_LOOKUP.keys())
+            self._attr_preset_mode = PRESET_NONE
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        self.async_write_ha_state()
 
     def _async_update_attrs(self) -> None:
         """Update attributes."""
@@ -538,15 +578,22 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
             self._attr_target_temperature = None
             self._attr_min_temp = 5
             self._attr_max_temp = 65
+            if device.support_special_status:
+                self._attr_preset_mode = AQUAREA_SPECIAL_STATUS_REVERSE_LOOKUP.get(
+                    device.special_status, PRESET_NONE
+                )
             return
 
         # Mode is at device level, not zone level
         self._attr_hvac_mode = convert_mode_and_status_to_hvac_mode(
             device.mode, zone.operation_status
         )
-        self._attr_hvac_action = convert_aquarea_action_to_hvac_action(
-            device.current_action
+
+        # Use device direction for more accurate HVAC action
+        self._attr_hvac_action = _get_hvac_action_from_device_direction(
+            device.current_direction, self._attr_hvac_mode
         )
+
         self._attr_current_temperature = zone.temperature
 
         # Target temperature depends on the current mode (heat or cool)
@@ -569,16 +616,34 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
             hvac_modes.append(HVACMode.HEAT_COOL)
         self._attr_hvac_modes = hvac_modes
 
+        # Update preset mode if supported
+        if device.support_special_status:
+            self._attr_preset_mode = AQUAREA_SPECIAL_STATUS_REVERSE_LOOKUP.get(
+                device.special_status, PRESET_NONE
+            )
+
+    async def _schedule_refresh(self, delay: float = AQUAREA_CLIMATE_DELAY_SHORT) -> None:
+        """Schedule a coordinator refresh after a short delay."""
+        await asyncio.sleep(delay)
+        try:
+            await self.coordinator.async_request_refresh()
+        except Exception:
+            _LOGGER.exception(
+                "Delayed refresh failed for device %s",
+                self.coordinator.device.device_id,
+            )
+
     async def async_turn_on(self) -> None:
         """Turn the climate entity on."""
         await self.coordinator.device.turn_on()
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))
 
     async def async_turn_off(self) -> None:
         """Turn the climate entity off."""
         await self.coordinator.device.turn_off()
         self._attr_hvac_mode = HVACMode.OFF
         self.async_write_ha_state()
+        self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new HVAC mode."""
@@ -590,7 +655,7 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
             mode=operation_mode,
             zone_id=self.entity_description.zone_id,
         )
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -602,3 +667,22 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
             )
         if mode := kwargs.get(ATTR_HVAC_MODE):
             await self.async_set_hvac_mode(mode)
+        self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if not self.coordinator.device.support_special_status:
+            return
+        if self.preset_modes is None or preset_mode not in self.preset_modes:
+            raise ValueError(f"Unsupported preset_mode '{preset_mode}'")
+        special_status = AQUAREA_SPECIAL_STATUS_LOOKUP.get(preset_mode)
+        _LOGGER.debug(
+            "Setting preset mode of device %s to %s (special_status=%s)",
+            self.coordinator.device.device_id,
+            preset_mode,
+            special_status,
+        )
+        await self.coordinator.device.set_special_status(special_status)
+        self._attr_preset_mode = preset_mode
+        self.async_write_ha_state()
+        self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))

--- a/custom_components/panasonic_cc/const.py
+++ b/custom_components/panasonic_cc/const.py
@@ -16,8 +16,6 @@ ATTR_SWING_LR_MODES = "horizontal_swing_modes"
 ATTR_STATE_ON = "on"
 ATTR_STATE_OFF = "off"
 
-STATE_HEATING = "heating"
-
 SERVICE_SET_SWING_LR_MODE = "set_horizontal_swing_mode"
 
 KEY_DOMAIN = "domain"
@@ -99,7 +97,8 @@ COMPONENT_TYPES = [
     Platform.BUTTON,
     Platform.SELECT,
     Platform.NUMBER,
-    Platform.WATER_HEATER
+    Platform.WATER_HEATER,
+    Platform.BINARY_SENSOR,
     ]
 
 STARTUP = """

--- a/custom_components/panasonic_cc/select.py
+++ b/custom_components/panasonic_cc/select.py
@@ -1,19 +1,43 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Callable
 from dataclasses import dataclass
 
+import aioaquarea
+from aioaquarea import PowerfulTime, QuietMode
+
 from homeassistant.core import HomeAssistant
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 
-from .const import DOMAIN, DATA_COORDINATORS
+from .const import DOMAIN, DATA_COORDINATORS, AQUAREA_COORDINATORS
 from aio_panasonic_comfort_cloud import PanasonicDevice, ChangeRequestBuilder, constants
 
-from .coordinator import PanasonicDeviceCoordinator
-from .base import PanasonicDataEntity
+from .coordinator import PanasonicDeviceCoordinator, AquareaDeviceCoordinator
+from .base import PanasonicDataEntity, AquareaDataEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+AQUAREA_SELECT_DELAY = 10.0
+
+QUIET_MODE_LOOKUP = {
+    "level1": QuietMode.LEVEL1,
+    "level2": QuietMode.LEVEL2,
+    "level3": QuietMode.LEVEL3,
+    "off": QuietMode.OFF,
+}
+
+QUIET_MODE_REVERSE_LOOKUP = {v: k for k, v in QUIET_MODE_LOOKUP.items()}
+
+POWERFUL_TIME_LOOKUP = {
+    "on-30m": PowerfulTime.ON_30MIN,
+    "on-60m": PowerfulTime.ON_60MIN,
+    "on-90m": PowerfulTime.ON_90MIN,
+    "off": PowerfulTime.OFF,
+}
+
+POWERFUL_TIME_REVERSE_LOOKUP = {v: k for k, v in POWERFUL_TIME_LOOKUP.items()}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -61,12 +85,18 @@ async def async_setup_entry(
     entry: Any,
     async_add_entities: Any,
 ) -> None:
-    """Set up the Panasonic select entities."""
+    """Set up the Panasonic and Aquarea select entities."""
     entities = []
     data_coordinators: list[PanasonicDeviceCoordinator] = hass.data[DOMAIN][DATA_COORDINATORS]
+    aquarea_coordinators: list[AquareaDeviceCoordinator] = hass.data[DOMAIN][AQUAREA_COORDINATORS]
     for coordinator in data_coordinators:
         entities.append(PanasonicSelectEntity(coordinator, HORIZONTAL_SWING_DESCRIPTION))
         entities.append(PanasonicSelectEntity(coordinator, VERTICAL_SWING_DESCRIPTION))
+
+    # Aquarea selects
+    for coordinator in aquarea_coordinators:
+        entities.append(AquareaQuietModeSelect(coordinator))
+        entities.append(AquareaPowerfulTimeSelect(coordinator))
 
     async_add_entities(entities)
 
@@ -104,3 +134,108 @@ class PanasonicSelectEntity(PanasonicDataEntity, SelectEntity):
         self._attr_current_option = self.entity_description.get_current_option(
             self.coordinator.device
         )
+
+
+# ---------------------------------------------------------------------------
+# Aquarea selects
+# ---------------------------------------------------------------------------
+
+class AquareaQuietModeSelect(AquareaDataEntity, SelectEntity):
+    """Select entity to configure the Aquarea device's quiet mode."""
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator, "quiet_mode")
+        self._attr_translation_key = "quiet_mode"
+        self._attr_options = list(QUIET_MODE_LOOKUP.keys())
+        self._attr_icon = "mdi:volume-off"
+        self._optimistic_option: str | None = None
+
+    @property
+    def current_option(self) -> str:
+        """The current select option."""
+        if self._optimistic_option is not None:
+            return self._optimistic_option
+        return QUIET_MODE_REVERSE_LOOKUP.get(
+            self.coordinator.device.quiet_mode, "off"
+        )
+
+    async def _schedule_refresh(self, delay: float = AQUAREA_SELECT_DELAY) -> None:
+        """Clear optimistic state and request a coordinator refresh after a short delay."""
+        await asyncio.sleep(delay)
+        self._optimistic_option = None
+        await self.coordinator.async_request_refresh()
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        if (quiet_mode := QUIET_MODE_LOOKUP.get(option)) is None:
+            return
+        if quiet_mode is self.coordinator.device.quiet_mode:
+            return
+        _LOGGER.debug(
+            "Setting Quiet Mode of device %s, from %s to %s",
+            self.coordinator.device.device_id,
+            str(self.coordinator.device.quiet_mode),
+            str(quiet_mode),
+        )
+        self._optimistic_option = option
+        self.async_write_ha_state()
+        await self.coordinator.device.set_quiet_mode(quiet_mode)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the select entity."""
+        pass
+
+
+class AquareaPowerfulTimeSelect(AquareaDataEntity, SelectEntity):
+    """Select entity to configure the Aquarea device's powerful time."""
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator, "powerful_time")
+        self._attr_translation_key = "powerful_time"
+        self._attr_options = list(POWERFUL_TIME_LOOKUP.keys())
+        self._optimistic_option: str | None = None
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        current = self.current_option
+        return "mdi:fire" if current != "off" else "mdi:fire-off"
+
+    @property
+    def current_option(self) -> str:
+        """The current select option."""
+        if self._optimistic_option is not None:
+            return self._optimistic_option
+        return POWERFUL_TIME_REVERSE_LOOKUP.get(
+            self.coordinator.device.powerful_time, "off"
+        )
+
+    async def _schedule_refresh(self, delay: float = AQUAREA_SELECT_DELAY) -> None:
+        """Clear optimistic state and request a coordinator refresh after a short delay."""
+        await asyncio.sleep(delay)
+        self._optimistic_option = None
+        await self.coordinator.async_request_refresh()
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        if (powerful_time := POWERFUL_TIME_LOOKUP.get(option)) is None:
+            return
+        if powerful_time is self.coordinator.device.powerful_time:
+            return
+        _LOGGER.debug(
+            "Setting Powerful Time of device %s, from %s to %s",
+            self.coordinator.device.device_id,
+            str(self.coordinator.device.powerful_time),
+            str(powerful_time),
+        )
+        self._optimistic_option = option
+        self.async_write_ha_state()
+        await self.coordinator.device.set_powerful_time(powerful_time)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the select entity."""
+        pass

--- a/custom_components/panasonic_cc/sensor.py
+++ b/custom_components/panasonic_cc/sensor.py
@@ -1,14 +1,22 @@
-from typing import Callable, Any
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 import logging
+from typing import Any
 
-from homeassistant.const import UnitOfTemperature, EntityCategory
+import aioaquarea
+
+from homeassistant.const import UnitOfEnergy, UnitOfTemperature, EntityCategory
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
     SensorDeviceClass,
-    SensorEntityDescription
+    SensorEntityDescription,
+    SensorExtraStoredData,
 )
+from homeassistant.core import callback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
 
 from aio_panasonic_comfort_cloud import PanasonicDevice, PanasonicDeviceEnergy, PanasonicDeviceZone, constants
 from aioaquarea import Device as AquareaDevice
@@ -175,6 +183,182 @@ AQUAREA_OUTSIDE_TEMPERATURE_DESCRIPTION = AquareaSensorEntityDescription(
     is_available=lambda device: device.temperature_outdoor is not None,
 )
 
+AQUAREA_TANK_TEMPERATURE_DESCRIPTION = AquareaSensorEntityDescription(
+    key="tank_temperature",
+    translation_key="tank_temperature",
+    name="Tank Temperature",
+    icon="mdi:thermometer",
+    device_class=SensorDeviceClass.TEMPERATURE,
+    state_class=SensorStateClass.MEASUREMENT,
+    native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    get_state=lambda device: device.tank.temperature if device.tank is not None else None,
+    is_available=lambda device: device.tank is not None,
+)
+
+AQUAREA_DIRECTION_DESCRIPTION = AquareaSensorEntityDescription(
+    key="direction",
+    translation_key="direction",
+    name="Direction",
+    icon="mdi:compass",
+    get_state=lambda device: device.current_direction.name,
+    is_available=lambda device: True,
+)
+
+AQUAREA_PUMP_STATUS_DESCRIPTION = AquareaSensorEntityDescription(
+    key="pump_status",
+    translation_key="pump_status",
+    name="Pump Status",
+    icon="mdi:pump",
+    get_state=lambda device: "On" if device.pump_duty == 1 else "Off",
+    is_available=lambda device: True,
+)
+
+# Energy consumption sensor descriptions for Aquarea
+@dataclass(frozen=True, kw_only=True)
+class AquareaEnergySensorEntityDescription(SensorEntityDescription):
+    """Describes Aquarea energy sensor entity."""
+    consumption_type: aioaquarea.ConsumptionType
+    exists_fn: Callable[[AquareaDeviceCoordinator], bool] = lambda _: True
+
+
+AQUAREA_ACCUMULATED_ENERGY_SENSORS = [
+    AquareaEnergySensorEntityDescription(
+        key="heating_accumulated_energy_consumption",
+        translation_key="heating_accumulated_energy_consumption",
+        name="Heating Accumulated Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.HEAT,
+    ),
+    AquareaEnergySensorEntityDescription(
+        key="cooling_accumulated_energy_consumption",
+        translation_key="cooling_accumulated_energy_consumption",
+        name="Cooling Accumulated Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.COOL,
+        exists_fn=lambda coordinator: any(zone.cool_mode for zone in coordinator.device.zones.values()),
+    ),
+    AquareaEnergySensorEntityDescription(
+        key="tank_accumulated_energy_consumption",
+        translation_key="tank_accumulated_energy_consumption",
+        name="Tank Accumulated Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.WATER_TANK,
+        exists_fn=lambda coordinator: coordinator.device.has_tank,
+    ),
+    AquareaEnergySensorEntityDescription(
+        key="accumulated_energy_consumption",
+        translation_key="accumulated_energy_consumption",
+        name="Accumulated Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.TOTAL,
+    ),
+]
+
+AQUAREA_ENERGY_SENSORS = [
+    AquareaEnergySensorEntityDescription(
+        key="heating_energy_consumption",
+        translation_key="heating_energy_consumption",
+        name="Heating Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.HEAT,
+        entity_registry_enabled_default=False,
+    ),
+    AquareaEnergySensorEntityDescription(
+        key="tank_energy_consumption",
+        translation_key="tank_energy_consumption",
+        name="Tank Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.WATER_TANK,
+        exists_fn=lambda coordinator: coordinator.device.has_tank,
+        entity_registry_enabled_default=False,
+    ),
+    AquareaEnergySensorEntityDescription(
+        key="cooling_energy_consumption",
+        translation_key="cooling_energy_consumption",
+        name="Cooling Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.COOL,
+        exists_fn=lambda coordinator: any(zone.cool_mode for zone in coordinator.device.zones.values()),
+        entity_registry_enabled_default=False,
+    ),
+    AquareaEnergySensorEntityDescription(
+        key="energy_consumption",
+        translation_key="energy_consumption",
+        name="Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        consumption_type=aioaquarea.ConsumptionType.TOTAL,
+        entity_registry_enabled_default=False,
+    ),
+]
+
+# Daily edge counter descriptions
+@dataclass(frozen=True, kw_only=True)
+class AquareaDailyCounterEntityDescription(SensorEntityDescription):
+    """Describes Aquarea daily counter sensor entity."""
+    detector: Callable[[AquareaDevice], bool]
+
+
+AQUAREA_DAILY_COUNTERS = [
+    AquareaDailyCounterEntityDescription(
+        key="dhw_cycles_today",
+        translation_key="dhw_cycles_today",
+        name="DHW Cycles Today",
+        icon="mdi:water-boiler",
+        device_class=SensorDeviceClass.ENUM,
+        state_class=SensorStateClass.TOTAL,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        detector=lambda device: device.current_direction == aioaquarea.DeviceDirection.WATER,
+    ),
+    AquareaDailyCounterEntityDescription(
+        key="zone_cycles_today",
+        translation_key="zone_cycles_today",
+        name="Zone Cycles Today",
+        icon="mdi:radiator",
+        device_class=SensorDeviceClass.ENUM,
+        state_class=SensorStateClass.TOTAL,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        detector=lambda device: (
+            device.current_direction == aioaquarea.DeviceDirection.PUMP
+            and any(zone.operation_status == aioaquarea.OperationStatus.ON for zone in device.zones.values())
+        ),
+    ),
+    AquareaDailyCounterEntityDescription(
+        key="defrost_cycles_today",
+        translation_key="defrost_cycles_today",
+        name="Defrost Cycles Today",
+        icon="mdi:snowflake-melt",
+        device_class=SensorDeviceClass.ENUM,
+        state_class=SensorStateClass.TOTAL,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        detector=lambda device: device.device_mode_status is aioaquarea.DeviceModeStatus.DEFROST,
+    ),
+]
+
+
 def create_zone_temperature_description(zone: PanasonicDeviceZone):
     return PanasonicSensorEntityDescription(
         key = f"zone-{zone.id}-temperature",
@@ -217,6 +401,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     for coordinator in aquarea_coordinators:
         entities.append(AquareaSensorEntity(coordinator, AQUAREA_OUTSIDE_TEMPERATURE_DESCRIPTION))
+        entities.append(AquareaPumpDirectionSensor(coordinator))
+        entities.append(AquareaPumpStatusSensor(coordinator))
+        if coordinator.device.has_tank:
+            entities.append(AquareaSensorEntity(coordinator, AQUAREA_TANK_TEMPERATURE_DESCRIPTION))
+        # Daily edge counters
+        for desc in AQUAREA_DAILY_COUNTERS:
+            entities.append(AquareaDailyCounterSensor(coordinator, desc))
+        # Accumulated energy sensors (month-to-date)
+        for desc in AQUAREA_ACCUMULATED_ENERGY_SENSORS:
+            if desc.exists_fn(coordinator):
+                entities.append(AquareaEnergyAccumulatedConsumptionSensor(coordinator, desc))
+        # Today's energy sensors (disabled by default)
+        for desc in AQUAREA_ENERGY_SENSORS:
+            if desc.exists_fn(coordinator):
+                entities.append(AquareaEnergyConsumptionSensor(coordinator, desc))
 
     async_add_entities(entities)
 
@@ -280,7 +479,7 @@ class PanasonicEnergySensorEntity(PanasonicEnergyEntity, SensorEntity):
         self._attr_native_value = value  # type: ignore[assignment]
 
 class AquareaSensorEntity(AquareaDataEntity, SensorEntity):
-    
+
     entity_description: AquareaSensorEntityDescription  # type: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, coordinator: AquareaDeviceCoordinator, description: AquareaSensorEntityDescription):
@@ -300,3 +499,193 @@ class AquareaSensorEntity(AquareaDataEntity, SensorEntity):
             self._attr_available = self.entity_description.is_available(self.coordinator.device)
         if self.entity_description.get_state:
             self._attr_native_value = self.entity_description.get_state(self.coordinator.device)
+
+
+class AquareaPumpDirectionSensor(AquareaDataEntity, SensorEntity):
+    """Sensor for the Aquarea pump direction."""
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, "direction")
+        self._attr_translation_key = "direction"
+        self._attr_icon = "mdi:compass"
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_native_value = self.coordinator.device.current_direction.name
+        super()._handle_coordinator_update()
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        self._attr_native_value = self.coordinator.device.current_direction.name
+
+
+class AquareaPumpStatusSensor(AquareaDataEntity, SensorEntity):
+    """Sensor for the Aquarea pump status."""
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, "pump_status")
+        self._attr_translation_key = "pump_status"
+        self._attr_icon = "mdi:pump"
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_native_value = "On" if self.coordinator.device.pump_duty == 1 else "Off"
+        super()._handle_coordinator_update()
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        self._attr_native_value = "On" if self.coordinator.device.pump_duty == 1 else "Off"
+
+
+class AquareaDailyCounterSensor(AquareaDataEntity, SensorEntity, RestoreEntity):
+    """Sensor that counts daily edge transitions (DHW cycles, zone cycles, defrost cycles)."""
+
+    entity_description: AquareaDailyCounterEntityDescription
+
+    def __init__(
+        self,
+        coordinator: AquareaDeviceCoordinator,
+        description: AquareaDailyCounterEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+        self._attr_translation_key = description.key
+        self._attr_icon = description.icon
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._count: int = 0
+        self._last_state: bool = False
+        self._last_date: datetime.date | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore count from previous session."""
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in (None, "unknown", "unavailable"):
+            try:
+                self._count = int(restored.state)
+            except ValueError:
+                self._count = 0
+        await super().async_added_to_hass()
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        device = self.coordinator.device
+        now = dt_util.now()
+        today = now.date()
+
+        # Reset counter at midnight
+        if self._last_date is None or self._last_date != today:
+            self._count = 0
+            self._last_date = today
+            self._last_state = False
+
+        current_state = self.entity_description.detector(device)
+
+        # Count rising edge transitions
+        if current_state and not self._last_state:
+            self._count += 1
+
+        self._last_state = current_state
+        self._attr_native_value = self._count
+
+
+class AquareaEnergyAccumulatedConsumptionSensor(AquareaDataEntity, SensorEntity, RestoreEntity):
+    """Sensor for accumulated (month-to-date) energy consumption from the Aquarea device."""
+
+    entity_description: AquareaEnergySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: AquareaDeviceCoordinator,
+        description: AquareaEnergySensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+        self._attr_translation_key = description.key
+        self._attr_device_class = description.device_class
+        self._attr_state_class = description.state_class
+        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._attr_suggested_display_precision = description.suggested_display_precision
+
+    async def async_added_to_hass(self) -> None:
+        """Restore value from previous session."""
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in (None, "unknown", "unavailable"):
+            try:
+                self._attr_native_value = float(restored.state)
+            except ValueError:
+                self._attr_native_value = 0
+        else:
+            self._attr_native_value = 0
+        await super().async_added_to_hass()
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        device = self.coordinator.device
+        # Get consumption data via the device's method
+        now = dt_util.now()
+        # Try to get month-to-date consumption
+        try:
+            consumption = device.get_or_schedule_consumption(
+                now, self.entity_description.consumption_type
+            )
+            if consumption is not None:
+                self._attr_native_value = float(consumption)
+        except aioaquarea.DataNotAvailableError:
+            pass  # Keep last known value
+        except Exception:
+            pass  # Keep last known value
+
+
+class AquareaEnergyConsumptionSensor(AquareaDataEntity, SensorEntity, RestoreEntity):
+    """Sensor for today's energy consumption from the Aquarea device."""
+
+    entity_description: AquareaEnergySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: AquareaDeviceCoordinator,
+        description: AquareaEnergySensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+        self._attr_translation_key = description.key
+        self._attr_device_class = description.device_class
+        self._attr_state_class = description.state_class
+        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._attr_suggested_display_precision = description.suggested_display_precision
+        self._attr_entity_registry_enabled_default = False
+
+    async def async_added_to_hass(self) -> None:
+        """Restore value from previous session."""
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in (None, "unknown", "unavailable"):
+            try:
+                self._attr_native_value = float(restored.state)
+            except ValueError:
+                self._attr_native_value = 0
+        else:
+            self._attr_native_value = 0
+        await super().async_added_to_hass()
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        device = self.coordinator.device
+        now = dt_util.now()
+        try:
+            consumption = device.get_or_schedule_consumption(
+                now, self.entity_description.consumption_type
+            )
+            if consumption is not None:
+                self._attr_native_value = float(consumption)
+        except aioaquarea.DataNotAvailableError:
+            pass  # Keep last known value
+        except Exception:
+            pass  # Keep last known value

--- a/custom_components/panasonic_cc/switch.py
+++ b/custom_components/panasonic_cc/switch.py
@@ -1,9 +1,12 @@
 """Support for Panasonic Nanoe and other switches."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Callable
 from dataclasses import dataclass
+
+import aioaquarea
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -21,14 +24,17 @@ from aio_panasonic_comfort_cloud import (
 
 from . import DOMAIN
 from .const import (
+    AQUAREA_COORDINATORS,
     CONF_FORCE_ENABLE_NANOE,
     DATA_COORDINATORS,
     DEFAULT_FORCE_ENABLE_NANOE,
 )
-from .coordinator import PanasonicDeviceCoordinator
-from .base import PanasonicDataEntity
+from .coordinator import PanasonicDeviceCoordinator, AquareaDeviceCoordinator
+from .base import PanasonicDataEntity, AquareaDataEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+AQUAREA_SWITCH_DELAY = 10.0
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -122,10 +128,13 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: Any,
 ) -> None:
-    """Set up the Panasonic switches."""
+    """Set up the Panasonic and Aquarea switches."""
     devices = []
     data_coordinators: list[PanasonicDeviceCoordinator] = hass.data[DOMAIN][
         DATA_COORDINATORS
+    ]
+    aquarea_coordinators: list[AquareaDeviceCoordinator] = hass.data[DOMAIN][
+        AQUAREA_COORDINATORS
     ]
     force_enable_nanoe = entry.options.get(
         CONF_FORCE_ENABLE_NANOE, DEFAULT_FORCE_ENABLE_NANOE
@@ -148,6 +157,13 @@ async def async_setup_entry(
                         data_coordinator, create_zone_mode_description(zone)
                     )
                 )
+
+    # Aquarea switches
+    for coordinator in aquarea_coordinators:
+        if coordinator.device.has_tank:
+            devices.append(AquareaForceDHWSwitch(coordinator))
+        devices.append(AquareaForceHeaterSwitch(coordinator))
+        devices.append(AquareaHolidayTimerSwitch(coordinator))
 
     async_add_entities(devices)
 
@@ -195,3 +211,139 @@ class PanasonicSwitchEntity(PanasonicDataEntity, SwitchEntity):
         self.entity_description.off_func(builder)
         await self.coordinator.async_apply_changes(builder)
         self._attr_is_on = False
+
+
+# ---------------------------------------------------------------------------
+# Aquarea switches
+# ---------------------------------------------------------------------------
+
+class AquareaBaseSwitch(AquareaDataEntity, SwitchEntity):
+    """Base class for Aquarea switches with optimistic updates."""
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _optimistic_is_on: bool | None = None
+
+    @property
+    def is_on(self) -> bool:
+        """Return the switch state."""
+        if self._optimistic_is_on is not None:
+            return self._optimistic_is_on
+        return self._get_is_on()
+
+    def _get_is_on(self) -> bool:
+        """Override in subclass to return the actual state from the device."""
+        raise NotImplementedError
+
+    async def _schedule_refresh(self, delay: float = AQUAREA_SWITCH_DELAY) -> None:
+        """Schedule a coordinator refresh after a short delay."""
+        await asyncio.sleep(delay)
+        self._optimistic_is_on = None
+        try:
+            await self.coordinator.async_request_refresh()
+        except aioaquarea.RequestFailedError:
+            _LOGGER.exception(
+                "Delayed refresh failed for device %s",
+                self.coordinator.device.device_id,
+            )
+
+
+class AquareaForceDHWSwitch(AquareaBaseSwitch):
+    """Switch to force DHW (domestic hot water) mode on Aquarea devices."""
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, "force_dhw")
+        self._attr_translation_key = "force_dhw"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return "mdi:water-boiler" if self.is_on else "mdi:water-boiler-off"
+
+    def _get_is_on(self) -> bool:
+        return self.coordinator.device.force_dhw is aioaquarea.ForceDHW.ON
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on Force DHW."""
+        self._optimistic_is_on = True
+        self.async_write_ha_state()
+        await self.coordinator.device.set_force_dhw(aioaquarea.ForceDHW.ON)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off Force DHW."""
+        self._optimistic_is_on = False
+        self.async_write_ha_state()
+        await self.coordinator.device.set_force_dhw(aioaquarea.ForceDHW.OFF)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    def _async_update_attrs(self) -> None:
+        """No-op — state is read via is_on property."""
+
+
+class AquareaForceHeaterSwitch(AquareaBaseSwitch):
+    """Switch to force heater mode on Aquarea devices."""
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, "force_heater")
+        self._attr_translation_key = "force_heater"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return "mdi:hvac" if self.is_on else "mdi:hvac-off"
+
+    def _get_is_on(self) -> bool:
+        return self.coordinator.device.force_heater is aioaquarea.ForceHeater.ON
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on Force Heater."""
+        self._optimistic_is_on = True
+        self.async_write_ha_state()
+        await self.coordinator.device.set_force_heater(aioaquarea.ForceHeater.ON)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off Force Heater."""
+        self._optimistic_is_on = False
+        self.async_write_ha_state()
+        await self.coordinator.device.set_force_heater(aioaquarea.ForceHeater.OFF)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    def _async_update_attrs(self) -> None:
+        """No-op — state is read via is_on property."""
+
+
+class AquareaHolidayTimerSwitch(AquareaBaseSwitch):
+    """Switch to enable/disable the holiday timer on Aquarea devices."""
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, "holiday_timer")
+        self._attr_translation_key = "holiday_timer"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return "mdi:timer-check" if self.is_on else "mdi:timer-off"
+
+    def _get_is_on(self) -> bool:
+        return self.coordinator.device.holiday_timer is aioaquarea.HolidayTimer.ON
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on Holiday Timer."""
+        self._optimistic_is_on = True
+        self.async_write_ha_state()
+        await self.coordinator.device.set_holiday_timer(aioaquarea.HolidayTimer.ON)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off Holiday Timer."""
+        self._optimistic_is_on = False
+        self.async_write_ha_state()
+        await self.coordinator.device.set_holiday_timer(aioaquarea.HolidayTimer.OFF)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    def _async_update_attrs(self) -> None:
+        """No-op — state is read via is_on property."""

--- a/custom_components/panasonic_cc/translations/en.json
+++ b/custom_components/panasonic_cc/translations/en.json
@@ -117,6 +117,95 @@
           "Down": "Bottom",
           "Swing": "Swing"
         }
+      },
+      "quiet_mode": {
+        "name": "Quiet Mode",
+        "state": {
+          "level1": "Level 1",
+          "level2": "Level 2",
+          "level3": "Level 3",
+          "off": "Off"
+        }
+      },
+      "powerful_time": {
+        "name": "Powerful Mode",
+        "state": {
+          "on-30m": "30 minutes",
+          "on-60m": "60 minutes",
+          "on-90m": "90 minutes",
+          "off": "Off"
+        }
+      }
+    },
+    "binary_sensor": {
+      "status": {
+        "name": "Error Status"
+      },
+      "defrost": {
+        "name": "Defrost"
+      }
+    },
+    "sensor": {
+      "outside_temperature": {
+        "name": "Outside Temperature"
+      },
+      "tank_temperature": {
+        "name": "Tank Temperature"
+      },
+      "direction": {
+        "name": "Direction"
+      },
+      "pump_status": {
+        "name": "Pump Status"
+      },
+      "dhw_cycles_today": {
+        "name": "DHW Cycles Today"
+      },
+      "zone_cycles_today": {
+        "name": "Zone Cycles Today"
+      },
+      "defrost_cycles_today": {
+        "name": "Defrost Cycles Today"
+      },
+      "heating_accumulated_energy_consumption": {
+        "name": "Heating Accumulated Consumption"
+      },
+      "cooling_accumulated_energy_consumption": {
+        "name": "Cooling Accumulated Consumption"
+      },
+      "tank_accumulated_energy_consumption": {
+        "name": "Tank Accumulated Consumption"
+      },
+      "accumulated_energy_consumption": {
+        "name": "Accumulated Consumption"
+      },
+      "heating_energy_consumption": {
+        "name": "Heating Consumption"
+      },
+      "cooling_energy_consumption": {
+        "name": "Cooling Consumption"
+      },
+      "tank_energy_consumption": {
+        "name": "Tank Consumption"
+      },
+      "energy_consumption": {
+        "name": "Consumption"
+      }
+    },
+    "switch": {
+      "force_dhw": {
+        "name": "Force DHW"
+      },
+      "force_heater": {
+        "name": "Force Heater"
+      },
+      "holiday_timer": {
+        "name": "Holiday Timer"
+      }
+    },
+    "button": {
+      "request_defrost": {
+        "name": "Request Defrost"
       }
     }
   },

--- a/custom_components/panasonic_cc/water_heater.py
+++ b/custom_components/panasonic_cc/water_heater.py
@@ -10,13 +10,13 @@ from homeassistant.components.water_heater import (
     STATE_HEAT_PUMP,
     STATE_OFF,
 )
-from homeassistant.const import UnitOfTemperature, PRECISION_WHOLE, ATTR_TEMPERATURE, STATE_IDLE
+from homeassistant.const import UnitOfTemperature, PRECISION_WHOLE, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 
 from .base import AquareaDataEntity
 from .coordinator import AquareaDeviceCoordinator
-from .const import DOMAIN, AQUAREA_COORDINATORS, STATE_HEATING
+from .const import DOMAIN, AQUAREA_COORDINATORS
 from aioaquarea.data import DeviceAction, OperationStatus
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ class AquareaWaterHeater(AquareaDataEntity, WaterHeaterEntity):
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = WaterHeaterEntityFeature.TARGET_TEMPERATURE | WaterHeaterEntityFeature.OPERATION_MODE
-    _attr_operation_list = [STATE_HEATING, STATE_OFF]
+    _attr_operation_list = [STATE_HEAT_PUMP, STATE_OFF]
     _attr_precision = PRECISION_WHOLE
     _attr_target_temperature_step = 1
     _attr_min_temp = 40
@@ -80,14 +80,8 @@ class AquareaWaterHeater(AquareaDataEntity, WaterHeaterEntity):
 
         if device.tank.operation_status == OperationStatus.OFF:
             self._attr_current_operation = STATE_OFF
-            self._attr_current_operation = STATE_OFF
         else:
             self._attr_current_operation = STATE_HEAT_PUMP
-            self._attr_current_operation = (
-                STATE_HEATING
-                if device.current_action == DeviceAction.HEATING_WATER
-                else STATE_IDLE
-            )
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -102,7 +96,7 @@ class AquareaWaterHeater(AquareaDataEntity, WaterHeaterEntity):
         """Set operation mode."""
         if self.coordinator.device.tank is None:
             return
-        if operation_mode == STATE_HEATING:
+        if operation_mode == STATE_HEAT_PUMP:
             await self.coordinator.device.tank.turn_on()
         elif operation_mode == STATE_OFF:
             await self.coordinator.device.tank.turn_off()


### PR DESCRIPTION
…and more

Add comprehensive entity support for Aquarea heat pump devices:

Sensors:
- Tank temperature sensor
- Pump direction and status sensors
- Daily cycle counters (DHW, zone, defrost) with state restoration
- Accumulated energy consumption sensors (month-to-date, per type)
- Today's energy consumption sensors (disabled by default)

Selects:
- Quiet mode (Level 1-3, Off)
- Powerful mode (30/60/90 min, Off)

Switches:
- Force DHW switch (when tank is present)
- Force heater switch
- Holiday timer switch

Buttons:
- Request defrost button

Binary sensors:
- Error status with error code/message attributes
- Defrost running indicator

Climate:
- Add HVAC action from device direction
- Add special status/preset support (ECO, Comfort)

Other:
- Fix water heater operation mode (STATE_HEAT_PUMP instead of STATE_HEATING)
- Add binary_sensor platform to component types
- Add English translations for all new entities