### PR TITLE
feat: add connection status monitoring and error classification

### DIFF
--- a/custom_components/panasonic_cc/aquarea/coordinator.py
+++ b/custom_components/panasonic_cc/aquarea/coordinator.py
@@ -23,6 +23,7 @@ from ..const import (
     DOMAIN,
     NOTIFICATION_AUTH_EXPIRED,
 )
+from ..error_handler import classify_error, FriendlyError, ErrorCategory
 
 MAX_CONSECUTIVE_FAILURES = 5
 BACKOFF_MULTIPLIER = 2
@@ -78,6 +79,23 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
         self._consecutive_failures = 0
         self._auth_failed = False
         self._last_device_state_hash: int | None = None
+        self._last_error: FriendlyError | None = None
+
+    @property
+    def last_error(self) -> FriendlyError | None:
+        """Return the last error that occurred."""
+        return self._last_error
+
+    @property
+    def connection_status(self) -> str:
+        """Return the current connection status."""
+        if self._auth_failed:
+            return "authentication_error"
+        if self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            return "disconnected"
+        if self._consecutive_failures > 0:
+            return "degraded"
+        return "connected"
 
     @property
     def device(self) -> AquareaDevice:
@@ -170,8 +188,9 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
                 )
                 _create_auth_expired_notification(self.hass)
                 raise UpdateFailed("Authentication failed — coordinator disabled") from err
-            self._handle_failure()
-            raise UpdateFailed(f"Invalid response from API: {err}") from err
+            self._handle_failure(err)
+            friendly = classify_error(err)
+            raise UpdateFailed(f"{friendly.title}: {friendly.message}") from err
         return self._update_id
 
     def _reset_backoff(self) -> None:
@@ -183,9 +202,10 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
                 self._consecutive_failures,
             )
         self._consecutive_failures = 0
+        self._last_error = None
         self.update_interval = timedelta(seconds=self._base_interval)
 
-    def _handle_failure(self) -> None:
+    def _handle_failure(self, err: Exception | None = None) -> None:
         """Handle API failure with exponential backoff."""
         self._consecutive_failures += 1
         new_interval = min(
@@ -193,13 +213,25 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
             MAX_UPDATE_INTERVAL,
         )
         self.update_interval = timedelta(seconds=new_interval)
-        _LOGGER.warning(
-            "%s API failure %d/%d — polling interval increased to %ds",
-            self._device_info.name,
-            self._consecutive_failures,
-            MAX_CONSECUTIVE_FAILURES,
-            new_interval,
-        )
+        if err is not None:
+            self._last_error = classify_error(err)
+            _LOGGER.warning(
+                "%s API failure %d/%d — %s: %s — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                self._last_error.title,
+                self._last_error.message,
+                new_interval,
+            )
+        else:
+            _LOGGER.warning(
+                "%s API failure %d/%d — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                new_interval,
+            )
 
     async def async_schedule_refresh(self) -> None:
         """Schedule a debounced refresh of device data."""

--- a/custom_components/panasonic_cc/aquarea/sensor.py
+++ b/custom_components/panasonic_cc/aquarea/sensor.py
@@ -25,6 +25,7 @@ from ..const import DOMAIN
 from .base import AquareaDataEntity
 from .coordinator import AquareaDeviceCoordinator
 from .const import AQUAREA_COORDINATORS
+from ..error_handler import ErrorCategory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,6 +76,9 @@ AQUAREA_PUMP_STATUS_DESCRIPTION = AquareaSensorEntityDescription(
     get_state=lambda device: "On" if device.pump_duty == 1 else "Off",
     is_available=lambda device: True,
 )
+
+# Connection status sensor options
+AQUAREA_CONNECTION_STATUS_OPTIONS = ["connected", "degraded", "disconnected", "authentication_error"]
 
 # Energy consumption sensor descriptions for Aquarea
 @dataclass(frozen=True, kw_only=True)
@@ -243,6 +247,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
         for desc in AQUAREA_ENERGY_SENSORS:
             if desc.exists_fn(coordinator):
                 entities.append(AquareaEnergyConsumptionSensor(coordinator, desc))
+        # Connection status sensor
+        entities.append(AquareaConnectionStatusSensor(coordinator))
 
     async_add_entities(entities)
 
@@ -456,3 +462,38 @@ class AquareaEnergyConsumptionSensor(AquareaDataEntity, SensorEntity, RestoreEnt
             pass  # Keep last known value
         except Exception:
             pass  # Keep last known value
+
+
+class AquareaConnectionStatusSensor(AquareaDataEntity, SensorEntity):
+    """Sensor that reports the connection status and error information for an Aquarea device."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "connection_status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = AQUAREA_CONNECTION_STATUS_OPTIONS
+    _attr_icon = "mdi:network"
+
+    def __init__(self, coordinator: AquareaDeviceCoordinator) -> None:
+        """Initialize the connection status sensor."""
+        super().__init__(coordinator, "connection_status")
+        self._attr_unique_id = f"{coordinator.device_id}-connection_status"
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        self._attr_native_value = self.coordinator.connection_status
+
+        # Build extra attributes with error details
+        attrs = {}
+        attrs["consecutive_failures"] = self.coordinator._consecutive_failures
+
+        if self.coordinator.last_error is not None:
+            err = self.coordinator.last_error
+            attrs["last_error_title"] = err.title
+            attrs["last_error_message"] = err.message
+            attrs["last_error_category"] = err.category.name.lower()
+            attrs["last_error_recoverable"] = err.is_recoverable
+            if err.suggestion:
+                attrs["last_error_suggestion"] = err.suggestion
+
+        self._attr_extra_state_attributes = attrs

--- a/custom_components/panasonic_cc/error_handler.py
+++ b/custom_components/panasonic_cc/error_handler.py
@@ -1,0 +1,276 @@
+"""Error classification and user-friendly error handling for Panasonic CC."""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+from aiohttp import ClientResponseError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ErrorCategory(Enum):
+    """Categories of errors that can occur with the Panasonic API."""
+    # Communication between Panasonic servers and the device
+    ADAPTER_COMMUNICATION = auto()
+    # Authentication / authorization issues
+    AUTHENTICATION = auto()
+    # Network connectivity issues (timeouts, DNS, etc.)
+    NETWORK = auto()
+    # Rate limiting from the API
+    RATE_LIMIT = auto()
+    # Server-side errors (5xx)
+    SERVER_ERROR = auto()
+    # Invalid request / bad parameters (4xx)
+    CLIENT_ERROR = auto()
+    # Unknown / unclassified errors
+    UNKNOWN = auto()
+
+
+@dataclass(frozen=True)
+class FriendlyError:
+    """A user-friendly representation of an error."""
+    category: ErrorCategory
+    title: str
+    message: str
+    suggestion: str | None = None
+    original_error: str = ""
+
+    @property
+    def is_recoverable(self) -> bool:
+        """Whether the error is likely to resolve on its own."""
+        return self.category in (
+            ErrorCategory.ADAPTER_COMMUNICATION,
+            ErrorCategory.NETWORK,
+            ErrorCategory.RATE_LIMIT,
+            ErrorCategory.SERVER_ERROR,
+        )
+
+    @property
+    def is_persistent(self) -> bool:
+        """Whether the error likely requires user action."""
+        return self.category in (
+            ErrorCategory.AUTHENTICATION,
+            ErrorCategory.CLIENT_ERROR,
+        )
+
+
+# Mapping of known API error codes to friendly errors
+KNOWN_ERROR_CODES = {
+    5005: FriendlyError(
+        category=ErrorCategory.ADAPTER_COMMUNICATION,
+        title="Device Communication Error",
+        message="The Panasonic server could not reach your air conditioner. The device may be offline, disconnected from the network, or the Panasonic cloud service is having trouble communicating with it.",
+        suggestion="Check that your AC unit is powered on and connected to the internet. If the problem persists, try restarting the AC unit or check the Panasonic app to see if the device is reachable there.",
+    ),
+    5001: FriendlyError(
+        category=ErrorCategory.ADAPTER_COMMUNICATION,
+        title="Device Not Responding",
+        message="Your air conditioner is not responding to commands. It may be offline or unreachable.",
+        suggestion="Verify the AC unit is powered on and has internet connectivity. Try controlling it from the Panasonic app to confirm.",
+    ),
+    429: FriendlyError(
+        category=ErrorCategory.RATE_LIMIT,
+        title="Rate Limited",
+        message="Too many requests have been sent to the Panasonic API. The server is temporarily rejecting requests.",
+        suggestion="This should resolve automatically. The integration will wait before retrying.",
+    ),
+    401: FriendlyError(
+        category=ErrorCategory.AUTHENTICATION,
+        title="Authentication Failed",
+        message="The integration could not authenticate with the Panasonic service. Your credentials may have expired or been invalidated.",
+        suggestion="Remove and re-add the integration to re-authenticate.",
+    ),
+    403: FriendlyError(
+        category=ErrorCategory.AUTHENTICATION,
+        title="Access Denied",
+        message="The integration does not have permission to access the requested resource.",
+        suggestion="Check that your account has access to this device in the Panasonic app.",
+    ),
+    404: FriendlyError(
+        category=ErrorCategory.CLIENT_ERROR,
+        title="Device Not Found",
+        message="The requested device was not found. It may have been removed from your account.",
+        suggestion="Verify the device still exists in your Panasonic account.",
+    ),
+    500: FriendlyError(
+        category=ErrorCategory.SERVER_ERROR,
+        title="Server Error",
+        message="The Panasonic server returned an internal error. This is a temporary issue on the server side.",
+        suggestion="This should resolve automatically. If it persists, check the Panasonic service status.",
+    ),
+    502: FriendlyError(
+        category=ErrorCategory.SERVER_ERROR,
+        title="Bad Gateway",
+        message="The Panasonic server received an invalid response from an upstream server.",
+        suggestion="This is a temporary server issue. It should resolve automatically.",
+    ),
+    503: FriendlyError(
+        category=ErrorCategory.SERVER_ERROR,
+        title="Service Unavailable",
+        message="The Panasonic service is temporarily unavailable, possibly due to maintenance or overload.",
+        suggestion="This should resolve automatically. Check the Panasonic service status if it persists.",
+    ),
+    504: FriendlyError(
+        category=ErrorCategory.SERVER_ERROR,
+        title="Gateway Timeout",
+        message="The Panasonic server timed out waiting for a response from an upstream service.",
+        suggestion="This is a temporary issue. It should resolve automatically.",
+    ),
+}
+
+# Regex patterns for error message matching (fallback when no code is found)
+ERROR_PATTERNS = [
+    (
+        re.compile(r"adapter\s+communication\s+error", re.IGNORECASE),
+        FriendlyError(
+            category=ErrorCategory.ADAPTER_COMMUNICATION,
+            title="Device Communication Error",
+            message="The Panasonic server could not reach your air conditioner. The device may be offline or disconnected from the network.",
+            suggestion="Check that your AC unit is powered on and connected to the internet. Try controlling it from the Panasonic app to confirm.",
+        ),
+    ),
+    (
+        re.compile(r"device\s+(not\s+)?respond(ing|ed)?", re.IGNORECASE),
+        FriendlyError(
+            category=ErrorCategory.ADAPTER_COMMUNICATION,
+            title="Device Not Responding",
+            message="Your air conditioner is not responding to commands.",
+            suggestion="Verify the AC unit is powered on and has internet connectivity.",
+        ),
+    ),
+    (
+        re.compile(r"timeout|timed?\s*out", re.IGNORECASE),
+        FriendlyError(
+            category=ErrorCategory.NETWORK,
+            title="Connection Timeout",
+            message="The request to the Panasonic service timed out. This could be a network issue or the service being slow.",
+            suggestion="Check your internet connection. If the problem persists, the Panasonic service may be experiencing issues.",
+        ),
+    ),
+    (
+        re.compile(r"unauthorized|authentication|invalid\s+(token|session|credentials)", re.IGNORECASE),
+        FriendlyError(
+            category=ErrorCategory.AUTHENTICATION,
+            title="Authentication Error",
+            message="The integration could not authenticate with the Panasonic service.",
+            suggestion="Remove and re-add the integration to re-authenticate.",
+        ),
+    ),
+    (
+        re.compile(r"rate\s+limit|too\s+many\s+requests", re.IGNORECASE),
+        FriendlyError(
+            category=ErrorCategory.RATE_LIMIT,
+            title="Rate Limited",
+            message="Too many requests have been sent to the Panasonic API.",
+            suggestion="This should resolve automatically. The integration will wait before retrying.",
+        ),
+    ),
+    (
+        re.compile(r"service\s+unavailable|maintenance", re.IGNORECASE),
+        FriendlyError(
+            category=ErrorCategory.SERVER_ERROR,
+            title="Service Unavailable",
+            message="The Panasonic service is temporarily unavailable.",
+            suggestion="This should resolve automatically. Check the Panasonic service status if it persists.",
+        ),
+    ),
+]
+
+
+def classify_error(err: Exception) -> FriendlyError:
+    """Classify an exception into a user-friendly error.
+
+    This function attempts to extract error codes and messages from the
+    exception and map them to a known friendly error. If no match is found,
+    it falls back to pattern matching on the error string, and finally
+    returns a generic unknown error.
+    """
+    error_str = str(err)
+
+    # Check for HTTP status code in the error string
+    # Pattern: "Expected status code '200' but received '500'"
+    status_match = re.search(r"received\s+['\"]?(\d{3})['\"]?", error_str)
+    if status_match:
+        status_code = int(status_match.group(1))
+        if status_code in KNOWN_ERROR_CODES:
+            return dataclasses.replace(KNOWN_ERROR_CODES[status_code], original_error=error_str)
+
+    # Check for JSON error code in response body
+    # Pattern: {"code":5005,"message":"Adapter Communication error"}
+    code_match = re.search(r'"code"\s*:\s*(\d+)', error_str)
+    if code_match:
+        error_code = int(code_match.group(1))
+        if error_code in KNOWN_ERROR_CODES:
+            return dataclasses.replace(KNOWN_ERROR_CODES[error_code], original_error=error_str)
+
+    # Check for HTTP status code patterns (401, 403, 404, 429, 500, etc.)
+    http_code_match = re.search(r"\b(4\d{2}|5\d{2})\b", error_str)
+    if http_code_match:
+        http_code = int(http_code_match.group(1))
+        if http_code in KNOWN_ERROR_CODES:
+            return dataclasses.replace(KNOWN_ERROR_CODES[http_code], original_error=error_str)
+
+    # Try pattern matching on error message
+    for pattern, friendly in ERROR_PATTERNS:
+        if pattern.search(error_str):
+            return dataclasses.replace(friendly, original_error=error_str)
+
+    # Check for ClientResponseError
+    if isinstance(err, ClientResponseError):
+        status = err.status
+        if status in KNOWN_ERROR_CODES:
+            return dataclasses.replace(KNOWN_ERROR_CODES[status], original_error=error_str)
+        if 400 <= status < 500:
+            return FriendlyError(
+                category=ErrorCategory.CLIENT_ERROR,
+                title=f"Client Error ({status})",
+                message=f"The request to the Panasonic service was rejected with status {status}.",
+                suggestion="This may be a temporary issue. If it persists, check the Panasonic app for device status.",
+                original_error=error_str,
+            )
+        if 500 <= status < 600:
+            return FriendlyError(
+                category=ErrorCategory.SERVER_ERROR,
+                title=f"Server Error ({status})",
+                message=f"The Panasonic server returned an error (status {status}).",
+                suggestion="This is likely a temporary issue on the server side. It should resolve automatically.",
+                original_error=error_str,
+            )
+
+    # Generic fallback
+    return FriendlyError(
+        category=ErrorCategory.UNKNOWN,
+        title="Unknown Error",
+        message=f"An unexpected error occurred while communicating with the Panasonic service: {error_str}",
+        suggestion="If this persists, please report the issue on the integration's GitHub page.",
+        original_error=error_str,
+    )
+
+
+def friendly_error_for_command_failure(
+    action: str,
+    device_name: str,
+    err: Exception,
+) -> FriendlyError:
+    """Create a friendly error for a command/action failure on a device.
+
+    Wraps the classified error with context about what action was being performed.
+    """
+    base = classify_error(err)
+
+    # For adapter communication errors during commands, provide more specific messaging
+    if base.category == ErrorCategory.ADAPTER_COMMUNICATION:
+        return FriendlyError(
+            category=ErrorCategory.ADAPTER_COMMUNICATION,
+            title="Device Communication Error",
+            message=f"The Panasonic server could not reach '{device_name}' while trying to {action.lower()}. The device may be offline, disconnected from the network, or the cloud service is having trouble communicating with it.",
+            suggestion="Check that your AC unit is powered on and connected to the internet. Try controlling it from the Panasonic app to confirm. If the device works in the app, this may be a temporary issue.",
+            original_error=str(err),
+        )
+
+    return base

--- a/custom_components/panasonic_cc/icons.json
+++ b/custom_components/panasonic_cc/icons.json
@@ -44,6 +44,16 @@
                 }
             }
         }
+      },
+      "sensor": {
+        "connection_status": {
+          "state": {
+            "connected": "mdi:network",
+            "degraded": "mdi:network-strength-2-alert",
+            "disconnected": "mdi:network-off",
+            "authentication_error": "mdi:account-alert"
+          }
+        }
       }
     }
   }

--- a/custom_components/panasonic_cc/panasonic/coordinator.py
+++ b/custom_components/panasonic_cc/panasonic/coordinator.py
@@ -27,6 +27,7 @@ from ..const import (
     CONF_DEVICE_FETCH_INTERVAL,
     CONF_ENERGY_FETCH_INTERVAL,
 )
+from ..error_handler import classify_error, FriendlyError, ErrorCategory
 
 MAX_CONSECUTIVE_FAILURES = 5
 BACKOFF_MULTIPLIER = 2
@@ -81,6 +82,29 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
         self._refresh_task: asyncio.Task | None = None
         self._consecutive_failures = 0
         self._auth_failed = False
+        self._last_error: FriendlyError | None = None
+        self._last_command_error: FriendlyError | None = None
+
+    @property
+    def last_error(self) -> FriendlyError | None:
+        """Return the last error that occurred."""
+        return self._last_error
+
+    @property
+    def last_command_error(self) -> FriendlyError | None:
+        """Return the last command error that occurred."""
+        return self._last_command_error
+
+    @property
+    def connection_status(self) -> str:
+        """Return the current connection status."""
+        if self._auth_failed:
+            return "authentication_error"
+        if self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            return "disconnected"
+        if self._consecutive_failures > 0:
+            return "degraded"
+        return "connected"
 
     @property
     def device(self) -> PanasonicDevice:
@@ -116,7 +140,25 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
 
     async def async_apply_changes(self, request_builder: ChangeRequestBuilder) -> None:
         """Apply changes to the device."""
-        await self._api_client.set_device_raw(self.device, request_builder.build())
+        try:
+            await self._api_client.set_device_raw(self.device, request_builder.build())
+            # Clear command error on success
+            self._last_command_error = None
+        except Exception as err:
+            friendly = classify_error(err)
+            self._last_command_error = friendly
+            # Also track the failure in the consecutive failures counter
+            # so the connection status sensor reflects the device state
+            self._handle_failure(err)
+            _LOGGER.warning(
+                "%s Command failed: %s — %s",
+                self._device_info.name,
+                friendly.title,
+                friendly.message,
+            )
+            # Notify listeners so the connection status sensor updates immediately
+            self.async_update_listeners()
+            raise
 
     async def async_schedule_refresh(self) -> None:
         """Schedule a debounced refresh of device data."""
@@ -176,8 +218,9 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
                 )
                 _create_auth_expired_notification(self.hass)
                 raise UpdateFailed("Authentication failed — coordinator disabled") from err
-            self._handle_failure()
-            raise UpdateFailed(f"Invalid response from API: {err}") from err
+            self._handle_failure(err)
+            friendly = classify_error(err)
+            raise UpdateFailed(f"{friendly.title}: {friendly.message}") from err
         return self._update_id
 
     def _reset_backoff(self) -> None:
@@ -189,9 +232,10 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
                 self._consecutive_failures,
             )
         self._consecutive_failures = 0
+        self._last_error = None
         self.update_interval = timedelta(seconds=self._base_interval)
 
-    def _handle_failure(self) -> None:
+    def _handle_failure(self, err: Exception | None = None) -> None:
         """Handle API failure with exponential backoff."""
         self._consecutive_failures += 1
         new_interval = min(
@@ -199,13 +243,25 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
             MAX_UPDATE_INTERVAL,
         )
         self.update_interval = timedelta(seconds=new_interval)
-        _LOGGER.warning(
-            "%s API failure %d/%d — polling interval increased to %ds",
-            self._device_info.name,
-            self._consecutive_failures,
-            MAX_CONSECUTIVE_FAILURES,
-            new_interval,
-        )
+        if err is not None:
+            self._last_error = classify_error(err)
+            _LOGGER.warning(
+                "%s API failure %d/%d — %s: %s — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                self._last_error.title,
+                self._last_error.message,
+                new_interval,
+            )
+        else:
+            _LOGGER.warning(
+                "%s API failure %d/%d — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                new_interval,
+            )
 
 
 class PanasonicDeviceEnergyCoordinator(DataUpdateCoordinator[int]):
@@ -234,6 +290,23 @@ class PanasonicDeviceEnergyCoordinator(DataUpdateCoordinator[int]):
         self._update_id = 0
         self._consecutive_failures = 0
         self._auth_failed = False
+        self._last_error: FriendlyError | None = None
+
+    @property
+    def last_error(self) -> FriendlyError | None:
+        """Return the last error that occurred."""
+        return self._last_error
+
+    @property
+    def connection_status(self) -> str:
+        """Return the current connection status."""
+        if self._auth_failed:
+            return "authentication_error"
+        if self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            return "disconnected"
+        if self._consecutive_failures > 0:
+            return "degraded"
+        return "connected"
 
     @property
     def api_client(self) -> ApiClient:
@@ -286,8 +359,9 @@ class PanasonicDeviceEnergyCoordinator(DataUpdateCoordinator[int]):
                 )
                 _create_auth_expired_notification(self.hass)
                 raise UpdateFailed("Authentication failed — coordinator disabled") from err
-            self._handle_failure()
-            raise UpdateFailed(f"Invalid response from API: {err}") from err
+            self._handle_failure(err)
+            friendly = classify_error(err)
+            raise UpdateFailed(f"{friendly.title}: {friendly.message}") from err
         return self._update_id
 
     def _reset_backoff(self) -> None:
@@ -299,9 +373,10 @@ class PanasonicDeviceEnergyCoordinator(DataUpdateCoordinator[int]):
                 self._consecutive_failures,
             )
         self._consecutive_failures = 0
+        self._last_error = None
         self.update_interval = timedelta(seconds=self._base_interval)
 
-    def _handle_failure(self) -> None:
+    def _handle_failure(self, err: Exception | None = None) -> None:
         """Handle API failure with exponential backoff."""
         self._consecutive_failures += 1
         new_interval = min(
@@ -309,10 +384,22 @@ class PanasonicDeviceEnergyCoordinator(DataUpdateCoordinator[int]):
             MAX_UPDATE_INTERVAL,
         )
         self.update_interval = timedelta(seconds=new_interval)
-        _LOGGER.warning(
-            "%s Energy API failure %d/%d — polling interval increased to %ds",
-            self._device_info.name,
-            self._consecutive_failures,
-            MAX_CONSECUTIVE_FAILURES,
-            new_interval,
-        )
+        if err is not None:
+            self._last_error = classify_error(err)
+            _LOGGER.warning(
+                "%s Energy API failure %d/%d — %s: %s — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                self._last_error.title,
+                self._last_error.message,
+                new_interval,
+            )
+        else:
+            _LOGGER.warning(
+                "%s Energy API failure %d/%d — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                new_interval,
+            )

--- a/custom_components/panasonic_cc/panasonic/number.py
+++ b/custom_components/panasonic_cc/panasonic/number.py
@@ -84,12 +84,20 @@ class PanasonicNumberEntity(PanasonicDataEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
-        int_value = int(value)
-        builder = self.coordinator.get_change_request_builder()
-        self.entity_description.set_value(builder, int_value)
-        await self.coordinator.async_apply_changes(builder)
-        await self.coordinator.async_schedule_refresh()
-        self._attr_native_value = int_value
+        try:
+            int_value = int(value)
+            builder = self.coordinator.get_change_request_builder()
+            self.entity_description.set_value(builder, int_value)
+            await self.coordinator.async_apply_changes(builder)
+            await self.coordinator.async_schedule_refresh()
+            self._attr_native_value = int_value
+        except Exception:
+            _LOGGER.exception(
+                "Failed to set value %s for number %s on device %s",
+                value,
+                self.entity_description.key,
+                self.coordinator.device_id,
+            )
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the number entity."""

--- a/custom_components/panasonic_cc/panasonic/select.py
+++ b/custom_components/panasonic_cc/panasonic/select.py
@@ -97,11 +97,19 @@ class PanasonicSelectEntity(PanasonicDataEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Select a new option."""
-        builder = self.coordinator.get_change_request_builder()
-        self.entity_description.set_option(builder, option)
-        await self.coordinator.async_apply_changes(builder)
-        await self.coordinator.async_schedule_refresh()
-        self._attr_current_option = option
+        try:
+            builder = self.coordinator.get_change_request_builder()
+            self.entity_description.set_option(builder, option)
+            await self.coordinator.async_apply_changes(builder)
+            await self.coordinator.async_schedule_refresh()
+            self._attr_current_option = option
+        except Exception:
+            _LOGGER.exception(
+                "Failed to select option '%s' for select %s on device %s",
+                option,
+                self.entity_description.key,
+                self.coordinator.device_id,
+            )
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the select entity."""

--- a/custom_components/panasonic_cc/panasonic/sensor.py
+++ b/custom_components/panasonic_cc/panasonic/sensor.py
@@ -21,6 +21,7 @@ from ..const import DOMAIN
 from .base import PanasonicDataEntity, PanasonicEnergyEntity
 from .coordinator import PanasonicDeviceCoordinator, PanasonicDeviceEnergyCoordinator
 from .const import DATA_COORDINATORS, ENERGY_COORDINATORS
+from ..error_handler import ErrorCategory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,6 +94,24 @@ DATA_MODE_DESCRIPTION = PanasonicSensorEntityDescription(
     state_class=None,
     native_unit_of_measurement=None,
     get_state=lambda device: device.info.status_data_mode.name,
+    is_available=lambda device: True,
+    entity_registry_enabled_default=True,
+)
+
+# Connection status sensor options
+CONNECTION_STATUS_OPTIONS = ["connected", "degraded", "disconnected", "authentication_error"]
+
+CONNECTION_STATUS_DESCRIPTION = PanasonicSensorEntityDescription(
+    key="connection_status",
+    translation_key="connection_status",
+    name="Connection Status",
+    icon="mdi:network",
+    options=CONNECTION_STATUS_OPTIONS,
+    device_class=SensorDeviceClass.ENUM,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    state_class=None,
+    native_unit_of_measurement=None,
+    get_state=lambda device: None,  # Handled by the entity itself
     is_available=lambda device: True,
     entity_registry_enabled_default=True,
 )
@@ -183,6 +202,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entities.append(PanasonicSensorEntity(coordinator, LAST_UPDATE_TIME_DESCRIPTION))
         entities.append(PanasonicSensorEntity(coordinator, DATA_AGE_DESCRIPTION))
         entities.append(PanasonicSensorEntity(coordinator, DATA_MODE_DESCRIPTION))
+        entities.append(PanasonicConnectionStatusSensor(coordinator))
         if coordinator.device.has_zones:
             for zone in coordinator.device.parameters.zones:
                 entities.append(PanasonicSensorEntity(
@@ -257,3 +277,46 @@ class PanasonicEnergySensorEntity(PanasonicEnergyEntity, SensorEntity):
         value = self.entity_description.get_state(energy)
         self._attr_available = value is not None
         self._attr_native_value = value  # type: ignore[assignment]
+
+
+class PanasonicConnectionStatusSensor(PanasonicDataEntity, SensorEntity):
+    """Sensor that reports the connection status and error information for a Panasonic device."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "connection_status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = CONNECTION_STATUS_OPTIONS
+    _attr_icon = "mdi:network"
+
+    def __init__(self, coordinator: PanasonicDeviceCoordinator) -> None:
+        """Initialize the connection status sensor."""
+        super().__init__(coordinator, "connection_status")
+        self._attr_unique_id = f"{coordinator.device_id}-connection_status"
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        self._attr_native_value = self.coordinator.connection_status
+
+        # Build extra attributes with error details
+        attrs = {}
+        attrs["consecutive_failures"] = self.coordinator._consecutive_failures
+
+        if self.coordinator.last_error is not None:
+            err = self.coordinator.last_error
+            attrs["last_error_title"] = err.title
+            attrs["last_error_message"] = err.message
+            attrs["last_error_category"] = err.category.name.lower()
+            attrs["last_error_recoverable"] = err.is_recoverable
+            if err.suggestion:
+                attrs["last_error_suggestion"] = err.suggestion
+
+        if self.coordinator.last_command_error is not None:
+            err = self.coordinator.last_command_error
+            attrs["last_command_error_title"] = err.title
+            attrs["last_command_error_message"] = err.message
+            attrs["last_command_error_category"] = err.category.name.lower()
+            if err.suggestion:
+                attrs["last_command_error_suggestion"] = err.suggestion
+
+        self._attr_extra_state_attributes = attrs

--- a/custom_components/panasonic_cc/panasonic/switch.py
+++ b/custom_components/panasonic_cc/panasonic/switch.py
@@ -184,16 +184,30 @@ class PanasonicSwitchEntity(PanasonicDataEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        builder = self.coordinator.get_change_request_builder()
-        self.entity_description.on_func(builder)
-        await self.coordinator.async_apply_changes(builder)
-        await self.coordinator.async_schedule_refresh()
-        self._attr_is_on = True
+        try:
+            builder = self.coordinator.get_change_request_builder()
+            self.entity_description.on_func(builder)
+            await self.coordinator.async_apply_changes(builder)
+            await self.coordinator.async_schedule_refresh()
+            self._attr_is_on = True
+        except Exception:
+            _LOGGER.exception(
+                "Failed to turn on switch %s for device %s",
+                self.entity_description.key,
+                self.coordinator.device_id,
+            )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        builder = self.coordinator.get_change_request_builder()
-        self.entity_description.off_func(builder)
-        await self.coordinator.async_apply_changes(builder)
-        await self.coordinator.async_schedule_refresh()
-        self._attr_is_on = False
+        try:
+            builder = self.coordinator.get_change_request_builder()
+            self.entity_description.off_func(builder)
+            await self.coordinator.async_apply_changes(builder)
+            await self.coordinator.async_schedule_refresh()
+            self._attr_is_on = False
+        except Exception:
+            _LOGGER.exception(
+                "Failed to turn off switch %s for device %s",
+                self.entity_description.key,
+                self.coordinator.device_id,
+            )

--- a/custom_components/panasonic_cc/translations/cs.json
+++ b/custom_components/panasonic_cc/translations/cs.json
@@ -118,6 +118,17 @@
           "Swing": "Kmitání"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Status připojení",
+        "state": {
+          "connected": "Připojeno",
+          "degraded": "Zhoršeno",
+          "disconnected": "Odpojeno",
+          "authentication_error": "Chyba ověření"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/de.json
+++ b/custom_components/panasonic_cc/translations/de.json
@@ -118,6 +118,17 @@
             "Swing": "Schwingen"
           }
         }
+      },
+      "sensor": {
+        "connection_status": {
+          "name": "Verbindungsstatus",
+          "state": {
+            "connected": "Verbunden",
+            "degraded": "Eingeschränkt",
+            "disconnected": "Getrennt",
+            "authentication_error": "Authentifizierungsfehler"
+          }
+        }
       }
     },
     "services": {

--- a/custom_components/panasonic_cc/translations/en.json
+++ b/custom_components/panasonic_cc/translations/en.json
@@ -190,6 +190,15 @@
       },
       "energy_consumption": {
         "name": "Consumption"
+      },
+      "connection_status": {
+        "name": "Connection Status",
+        "state": {
+          "connected": "Connected",
+          "degraded": "Degraded",
+          "disconnected": "Disconnected",
+          "authentication_error": "Authentication Error"
+        }
       }
     },
     "switch": {

--- a/custom_components/panasonic_cc/translations/es.json
+++ b/custom_components/panasonic_cc/translations/es.json
@@ -118,6 +118,17 @@
           "Swing": "Oscilación"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Estado de conexión",
+        "state": {
+          "connected": "Conectado",
+          "degraded": "Degradado",
+          "disconnected": "Desconectado",
+          "authentication_error": "Error de autenticación"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/fr.json
+++ b/custom_components/panasonic_cc/translations/fr.json
@@ -118,6 +118,17 @@
           "Swing": "Balancement"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "État de connexion",
+        "state": {
+          "connected": "Connecté",
+          "degraded": "Dégradé",
+          "disconnected": "Déconnecté",
+          "authentication_error": "Erreur d'authentification"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/it.json
+++ b/custom_components/panasonic_cc/translations/it.json
@@ -118,6 +118,17 @@
           "Swing": "Oscilla"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Stato connessione",
+        "state": {
+          "connected": "Connesso",
+          "degraded": "Degradato",
+          "disconnected": "Disconnesso",
+          "authentication_error": "Errore di autenticazione"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/nb.json
+++ b/custom_components/panasonic_cc/translations/nb.json
@@ -118,6 +118,17 @@
           "Swing": "Sving"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Tilkoblingsstatus",
+        "state": {
+          "connected": "Tilkoblet",
+          "degraded": "Forverret",
+          "disconnected": "Frakoblet",
+          "authentication_error": "Autentiseringsfeil"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/nl.json
+++ b/custom_components/panasonic_cc/translations/nl.json
@@ -118,6 +118,17 @@
           "Swing": "Zwaaien"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Verbindingsstatus",
+        "state": {
+          "connected": "Verbonden",
+          "degraded": "Verslechterd",
+          "disconnected": "Verbroken",
+          "authentication_error": "Authenticatiefout"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/pl.json
+++ b/custom_components/panasonic_cc/translations/pl.json
@@ -117,6 +117,17 @@
           "Down": "Niski"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Status połączenia",
+        "state": {
+          "connected": "Połączono",
+          "degraded": "Degradowany",
+          "disconnected": "Rozłączono",
+          "authentication_error": "Błąd uwierzytelniania"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/pt.json
+++ b/custom_components/panasonic_cc/translations/pt.json
@@ -118,6 +118,17 @@
           "Swing": "Oscilação"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Estado da ligação",
+        "state": {
+          "connected": "Ligado",
+          "degraded": "Degradado",
+          "disconnected": "Desligado",
+          "authentication_error": "Erro de autenticação"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/panasonic_cc/translations/sv.json
+++ b/custom_components/panasonic_cc/translations/sv.json
@@ -118,6 +118,17 @@
           "Swing": "Svängande"
         }
       }
+    },
+    "sensor": {
+      "connection_status": {
+        "name": "Anslutningsstatus",
+        "state": {
+          "connected": "Ansluten",
+          "degraded": "Försämrad",
+          "disconnected": "Frånkopplad",
+          "authentication_error": "Autentiseringsfel"
+        }
+      }
     }
   },
   "services": {


### PR DESCRIPTION
- Add error_handler module with FriendlyError and ErrorCategory for classifying API errors into user-friendly messages with recoverability info

- Add connection_status property to Panasonic and Aquarea coordinators tracking connected/degraded/disconnected/authentication_error states

- Add Connection Status diagnostic sensor to both Panasonic and Aquarea platforms with detailed error attributes (consecutive failures, last error title/message/category, suggestions)

- Improve coordinator error handling to classify and log friendly error messages instead of raw exceptions

- Add try/except error handling with logging to switch, number, and select entity action methods

- Add dynamic icons for connection status states in icons.json

- Add connection_status translations for all 10 supported languages