### PR TITLE
fix: keep last data during transient 5xx/429 Panasonic errors

### DIFF
--- a/custom_components/panasonic_cc/error_handler.py
+++ b/custom_components/panasonic_cc/error_handler.py
@@ -121,6 +121,12 @@ KNOWN_ERROR_CODES = {
         message="The Panasonic server timed out waiting for a response from an upstream service.",
         suggestion="This is a temporary issue. It should resolve automatically.",
     ),
+    5300: FriendlyError(
+        category=ErrorCategory.SERVER_ERROR,
+        title="Service Under Maintenance",
+        message="The Panasonic service is temporarily unavailable due to scheduled maintenance.",
+        suggestion="This should resolve automatically once maintenance is complete.",
+    ),
 }
 
 # Regex patterns for error message matching (fallback when no code is found)

--- a/custom_components/panasonic_cc/panasonic/coordinator.py
+++ b/custom_components/panasonic_cc/panasonic/coordinator.py
@@ -218,8 +218,21 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
                 )
                 _create_auth_expired_notification(self.hass)
                 raise UpdateFailed("Authentication failed — coordinator disabled") from err
-            self._handle_failure(err)
             friendly = classify_error(err)
+            if (
+                friendly.category in (ErrorCategory.RATE_LIMIT, ErrorCategory.SERVER_ERROR)
+                and self._device is not None
+            ):
+                self._handle_failure(err)
+                _LOGGER.warning(
+                    "%s Transient error %s: %s — keeping last device data and retrying after backoff.",
+                    self._device_info.name,
+                    friendly.title,
+                    friendly.message,
+                )
+                self.async_update_listeners()
+                return self._update_id
+            self._handle_failure(err)
             raise UpdateFailed(f"{friendly.title}: {friendly.message}") from err
         return self._update_id
 
@@ -359,8 +372,21 @@ class PanasonicDeviceEnergyCoordinator(DataUpdateCoordinator[int]):
                 )
                 _create_auth_expired_notification(self.hass)
                 raise UpdateFailed("Authentication failed — coordinator disabled") from err
-            self._handle_failure(err)
             friendly = classify_error(err)
+            if (
+                friendly.category in (ErrorCategory.RATE_LIMIT, ErrorCategory.SERVER_ERROR)
+                and self._energy is not None
+            ):
+                self._handle_failure(err)
+                _LOGGER.warning(
+                    "%s Transient error %s: %s — keeping last energy data and retrying after backoff.",
+                    self._device_info.name,
+                    friendly.title,
+                    friendly.message,
+                )
+                self.async_update_listeners()
+                return self._update_id
+            self._handle_failure(err)
             raise UpdateFailed(f"{friendly.title}: {friendly.message}") from err
         return self._update_id
 


### PR DESCRIPTION
Closes #371\nCloses #403\n\nRoot cause: on transient 504/429 from the Panasonic energy endpoint, the coordinators raised UpdateFailed, bouncing energy/temperature entities to unavailable after every restart or outage.\n\nFix: classify RATE_LIMIT/SERVER_ERROR as transient — keep the last good device/energy value, back off, and retry instead of clearing availability. Persistent errors (auth, client) still raise UpdateFailed.\n\nVerification: compile-only (no HA test harness in this repo).