### PR TITLE
fix: suggest Celsius display unit for temperature entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ data:
 - **Cached data** — If your device is offline, the integration will show cached data. Check the "Data Mode" diagnostic sensor to see if data is LIVE, CACHED, or OFFLINE.
 - **Stale readings** — Use the "Fetch latest data" button to manually refresh device data.
 - **No outside temperature** — Not all devices report outside temperature. Use the "Force outside sensor" option if you want the sensor entity to always appear.
+- **Temperature display unit** — Temperature entities report in Celsius natively and follow HA's unit system for display. To show a specific unit, set the entity's display unit in HA or change the HA unit system.
 
 ### Energy Sensors
 - **Energy data not updating** — Ensure "Enable daily energy sensors" is checked in the integration options. Note that energy data resets daily.

--- a/custom_components/panasonic_cc/aquarea/sensor.py
+++ b/custom_components/panasonic_cc/aquarea/sensor.py
@@ -43,6 +43,7 @@ AQUAREA_OUTSIDE_TEMPERATURE_DESCRIPTION = AquareaSensorEntityDescription(
     device_class=SensorDeviceClass.TEMPERATURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
     get_state=lambda device: device.temperature_outdoor,
     is_available=lambda device: device.temperature_outdoor is not None,
 )
@@ -55,6 +56,7 @@ AQUAREA_TANK_TEMPERATURE_DESCRIPTION = AquareaSensorEntityDescription(
     device_class=SensorDeviceClass.TEMPERATURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
     get_state=lambda device: device.tank.temperature if device.tank is not None else None,
     is_available=lambda device: device.tank is not None,
 )

--- a/custom_components/panasonic_cc/panasonic/sensor.py
+++ b/custom_components/panasonic_cc/panasonic/sensor.py
@@ -44,6 +44,7 @@ INSIDE_TEMPERATURE_DESCRIPTION = PanasonicSensorEntityDescription(
     device_class=SensorDeviceClass.TEMPERATURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
     get_state=lambda device: device.parameters.inside_temperature,
     is_available=lambda device: device.parameters.inside_temperature is not None,
 )
@@ -55,6 +56,7 @@ OUTSIDE_TEMPERATURE_DESCRIPTION = PanasonicSensorEntityDescription(
     device_class=SensorDeviceClass.TEMPERATURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
     get_state=lambda device: device.parameters.outside_temperature,
     is_available=lambda device: device.parameters.outside_temperature is not None,
 )
@@ -186,6 +188,7 @@ def create_zone_temperature_description(zone: PanasonicDeviceZone):
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
         get_state=lambda device: zone.temperature,
         is_available=lambda device: zone.has_temperature
     )


### PR DESCRIPTION
Closes #441

Reported symptom: temperature displayed in Fahrenheit for a user expecting Celsius.

Fix (conservative): set suggested_unit_of_measurement = Celsius on all Panasonic/Aquarea temperature sensor descriptions so HA's unit-system/display-unit handling is predictable, without converting native values. Climate entities keep their native Celsius unit. Users on a Fahrenheit unit system can still switch the entity display unit in HA as desired.

Note: this is a display/UX fix; root cause may also involve the reporter's HA unit-system configuration.

Verification: compile-only (no HA test harness in this repo).