### PR TITLE
feat: allow lower minimum target temperature (13.5C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is a custom integration to control Panasonic Comfort Cloud devices in [Home
 - Target temperature control
 - Fan mode selection
 - Preset modes (Quiet, Powerful, +8/15°C heat)
+- Minimum target temperature is set to 13.5°C to support units that allow lower setpoints. If your unit rejects low temperatures, it simply won't go below its hardware limit; per-model minimums are not exposed by the upstream library.
 
 ### Water Heater
 - **Aquarea Hot Water Tank** — Water heater entity with target temperature control (40–65°C), operation modes (Heat Pump, Off)

--- a/custom_components/panasonic_cc/panasonic/climate.py
+++ b/custom_components/panasonic_cc/panasonic/climate.py
@@ -34,6 +34,8 @@ from .const import (
     PRESET_BOOST,
     PRESET_QUIET,
     PRESET_POWERFUL,
+    DEFAULT_MIN_TEMPERATURE,
+    LOWERED_MIN_TEMPERATURE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -128,7 +130,7 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
-    _attr_min_temp = 16
+    _attr_min_temp = DEFAULT_MIN_TEMPERATURE
     _attr_max_temp = 30
     _attr_supported_features = SUPPORT_FLAGS
     _attr_fan_modes = [f.name for f in constants.FanSpeed]
@@ -227,7 +229,9 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
     def _set_temp_range(self) -> None:
         """Set new target temperature range."""
         device = self.coordinator.device
-        self._attr_min_temp = 8 if device.in_summer_house_mode else 16
+        self._attr_min_temp = (
+            8 if device.in_summer_house_mode else LOWERED_MIN_TEMPERATURE
+        )
         if device.in_summer_house_mode:
             self._attr_max_temp = 15 if device.features.summer_house == 2 else 10
         else:
@@ -317,6 +321,10 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
         try:
             builder = self.coordinator.get_change_request_builder()
             if temp := kwargs.get(ATTR_TEMPERATURE):
+                if temp < self._attr_min_temp:
+                    temp = self._attr_min_temp
+                elif temp > self._attr_max_temp:
+                    temp = self._attr_max_temp
                 builder.set_target_temperature(temp)
             if mode := kwargs.get("hvac_mode"):
                 if op_mode := convert_hvac_mode_to_operation_mode(mode):
@@ -371,7 +379,7 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
 
     async def _async_exit_summer_house_mode(self, builder: ChangeRequestBuilder):
         """Exit summer house mode."""
-        self._attr_min_temp = 16
+        self._attr_min_temp = LOWERED_MIN_TEMPERATURE
         self._attr_max_temp = 30
         if not self.coordinator.device.in_summer_house_mode:
             return

--- a/custom_components/panasonic_cc/panasonic/const.py
+++ b/custom_components/panasonic_cc/panasonic/const.py
@@ -18,6 +18,9 @@ SERVICE_SET_SWING_LR_MODE = "set_horizontal_swing_mode"
 
 SENSOR_TYPE_TEMPERATURE = "temperature"
 
+DEFAULT_MIN_TEMPERATURE = 16
+LOWERED_MIN_TEMPERATURE = 13.5
+
 PRESET_8_15 = "heat_8_15"
 PRESET_QUIET = "quiet"
 PRESET_POWERFUL = "powerful"


### PR DESCRIPTION
Refs #427

The climate entity hardcoded a 16C minimum; some units support down to ~13.5C. Since the upstream library exposes no per-model minimum, this lowers the default floor to 13.5C and clamps setpoint requests to the active min/max. Units without that capability will ignore the lower value.

Verification: compile-only (no HA test harness in this repo).