### PR TITLE
fix: surface detected fan/preset features for diagnosis

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This is a custom integration to control Panasonic Comfort Cloud devices in [Home
 - Fan mode selection
 - Preset modes (Quiet, Powerful, +8/15°C heat)
 
+> [!NOTE]
+> Quiet/Powerful presets and supported fan speeds (e.g. Auto on some models) depend on capability flags reported by the Comfort Cloud service. If a preset or fan mode is unavailable or rejected by the unit, enable debug logging for the integration — the offered modes and detected features are logged at setup. Full per-model fan-speed support is tracked upstream in aio-panasonic-comfort-cloud.
+
 ### Water Heater
 - **Aquarea Hot Water Tank** — Water heater entity with target temperature control (40–65°C), operation modes (Heat Pump, Off)
 

--- a/custom_components/panasonic_cc/panasonic/climate.py
+++ b/custom_components/panasonic_cc/panasonic/climate.py
@@ -193,6 +193,15 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
 
         super().__init__(coordinator, description.key)
 
+        _LOGGER.debug(
+            "%s (model %s) setup - hvac_modes: %s, preset_modes: %s, fan_modes: %s",
+            coordinator.device_info.name,
+            coordinator.device_info.model,
+            self._attr_hvac_modes,
+            self._attr_preset_modes,
+            self._attr_fan_modes,
+        )
+
     def _async_update_attrs(self) -> None:
         """Update attributes."""
         state = self.coordinator.device.parameters

--- a/custom_components/panasonic_cc/panasonic/coordinator.py
+++ b/custom_components/panasonic_cc/panasonic/coordinator.py
@@ -201,6 +201,19 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
                     self._device.has_eco_navi,
                     self._device.has_eco_function,
                 )
+                _LOGGER.debug(
+                    "%s (model %s) fan/preset features - quiet_mode: %s, powerful_mode: %s, auto_mode: %s, cool_mode: %s, heat_mode: %s, dry_mode: %s, summer_house: %s, has_iauto_x: %s",
+                    self._device_info.name,
+                    self._device_info.model,
+                    self._device.features.quiet_mode,
+                    self._device.features.powerful_mode,
+                    self._device.features.auto_mode,
+                    self._device.features.cool_mode,
+                    self._device.features.heat_mode,
+                    self._device.features.dry_mode,
+                    self._device.features.summer_house,
+                    self._device.has_iauto_x,
+                )
                 self._update_id = 1
                 self._reset_backoff()
                 return self._update_id


### PR DESCRIPTION
Refs #381
Refs #443

Root cause: detection of quiet/powerful presets and per-model supported fan speeds is provided by aio-panasonic-comfort-cloud, which exposes no per-device fan-speed capability list today. So the integration cannot filter Auto/quiet/powerful per model.

Repo-side mitigation: log the detected features and the offered hvac/preset/fan modes at setup so users (and maintainers) can confirm from debug logs which capabilities were detected. A full fix (per-model fan-speed capability filtering) requires an upstream library change.

Verification: compile-only (no HA test harness in this repo).