### PR TITLE
fix: log detected Aquarea zones for thermostat diagnosis

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ data:
 - **Energy data not updating** — Ensure "Enable daily energy sensors" is checked in the integration options. Note that energy data resets daily.
 - **Current power seems inaccurate** — Current power is extrapolated from the daily energy reading and may not reflect instantaneous power accurately.
 
+### Aquarea
+If no thermostat/climate entity appears for your Aquarea monoblock (e.g. WH-SDC0509 + WH-WDG), the device may report no zones to the integration. Enable debug logging — the number of detected zones is logged at startup. Zone availability depends on the upstream aioaquarea library.
+
 ---
 
 ## Dependencies

--- a/custom_components/panasonic_cc/aquarea/__init__.py
+++ b/custom_components/panasonic_cc/aquarea/__init__.py
@@ -65,6 +65,11 @@ async def async_setup_aquarea(
     aquarea_coordinators_uninitialized: list[tuple[AquareaDeviceCoordinator, AquareaDeviceInfo]] = []
 
     for aquarea_device in aquarea_devices:
+        _LOGGER.debug(
+            "Aquarea device discovered: id=%s name=%s",
+            getattr(aquarea_device, "id", None),
+            aquarea_device.name,
+        )
         try:
             aquarea_coordinator = AquareaDeviceCoordinator(
                 hass, config, aquarea_api, aquarea_device
@@ -89,6 +94,26 @@ async def async_setup_aquarea(
                 device_info.name,
                 exc,
                 exc_info=True,
+            )
+            return
+
+        device = coordinator.device
+        zones = device.zones
+        zone_summary = [
+            {"zone_id": zone_id, "name": zone.name} for zone_id, zone in zones.items()
+        ]
+        _LOGGER.debug(
+            "Aquarea device %s (model=%s, id=%s) reported %d zone(s): %s",
+            device.device_name,
+            device.model,
+            device.device_id,
+            len(zones),
+            zone_summary,
+        )
+        if not zones:
+            _LOGGER.info(
+                "Aquarea device %s reported no zones; no climate/thmostat entity will be created. Zone exposure may depend on the aioaquarea library.",
+                device.device_name,
             )
 
     await asyncio.gather(

--- a/custom_components/panasonic_cc/aquarea/climate.py
+++ b/custom_components/panasonic_cc/aquarea/climate.py
@@ -301,4 +301,9 @@ async def async_setup_entry(
                     ),
                 )
             )
+    _LOGGER.debug(
+        "Aquarea climate: created %d climate entity(ies) across %d coordinator(s)",
+        len(entities),
+        len(aquarea_coordinators),
+    )
     async_add_entities(entities)


### PR DESCRIPTION
Refs #459

Aquarea climate entities are created per zone; some monoblocks report no zones, so no thermostat appears. This adds debug logging of detected zones per device and an info note when a device has none, plus a README troubleshooting note. Full zone exposure is handled by the upstream aioaquarea library.

Verification: compile-only (no HA test harness in this repo).