### PR TITLE
chore: ensure power-on when setting HVAC mode

### DIFF
--- a/custom_components/panasonic_cc/panasonic/climate.py
+++ b/custom_components/panasonic_cc/panasonic/climate.py
@@ -302,6 +302,7 @@ class PanasonicClimateEntity(PanasonicDataEntity, ClimateEntity):
             builder = self.coordinator.get_change_request_builder()
             await self._async_exit_summer_house_mode(builder)
             builder.set_hvac_mode(op_mode)
+            builder.set_power_mode(constants.Power.On)
             await self.coordinator.async_apply_changes(builder)
             await self.coordinator.async_schedule_refresh()
             self._update_attributes(builder)


### PR DESCRIPTION
Addresses the breaking change from the library introduced by PR https://github.com/sockless-coding/aio-panasonic-comfort-cloud/pull/23.