### PR TITLE
feat: add HWS hot water tank support and migrate Aquarea to unified API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 [![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&style=for-the-badge&logo=home-assistant&label=usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.panasonic_cc.total)](https://analytics.home-assistant.io/)
 
-This is a custom integration to control Panasonic Comfort Cloud devices in [Home Assistant](https://home-assistant.io). It supports both Panasonic air conditioners/heat pumps and Panasonic Aquarea heat pump systems.
+This is a custom integration to control Panasonic Comfort Cloud devices in [Home Assistant](https://home-assistant.io). It supports Panasonic air conditioners/heat pumps, Panasonic Aquarea air-to-water heat pump systems, and standalone HWS heat pump hot water tanks.
 
 > [!IMPORTANT]
 > Before installing this integration, please ensure the following steps have been completed in the Panasonic Comfort Cloud App:
@@ -35,6 +35,7 @@ This is a custom integration to control Panasonic Comfort Cloud devices in [Home
 
 ### Water Heater
 - **Aquarea Hot Water Tank** — Water heater entity with target temperature control (40–65°C), operation modes (Heat Pump, Off)
+- **HWS Hot Water Tank** — Water heater entity for standalone HWS heat pump hot water tanks (e.g. HE-UM40CR), target temperature control, operation modes (Heat Pump, Off)
 
 ### Swing Control
 - Horizontal swing mode via Select entity
@@ -50,6 +51,7 @@ This is a custom integration to control Panasonic Comfort Cloud devices in [Home
 - **Force DHW** — Force domestic hot water mode (Aquarea, where available)
 - **Force Heater** — Force heater mode (Aquarea)
 - **Holiday Timer** — Enable/disable holiday timer (Aquarea)
+- **Boost Mode** — Toggle boost mode (HWS)
 
 ### Sensors
 - **Inside Temperature** — Indoor temperature reading
@@ -66,10 +68,14 @@ This is a custom integration to control Panasonic Comfort Cloud devices in [Home
 - **Cached Data Age** — Timestamp of cached data when device is offline (diagnostic)
 - **Data Mode** — Current data mode: LIVE, CACHED, or OFFLINE (diagnostic)
 - **Outside Temperature** — Outdoor temperature reading (Aquarea)
-- **Tank Temperature** — Hot water tank temperature (Aquarea, where available)
+- **Tank Temperature** — Hot water tank temperature (Aquarea and HWS, where available)
 - **Direction** — Current operating direction (Aquarea)
 - **Pump Status** — On/Off pump status (Aquarea)
-- **Accumulated Energy** — Heating, cooling, tank, and total accumulated energy consumption in kWh (Aquarea)
+- **Consumption Today** — Heating, cooling, tank, and total energy consumption for today, in kWh (Aquarea, optional)
+- **Cost Today** — Heating, cooling, and tank cost for today (Aquarea, optional, disabled by default)
+- **DHW/Zone/Defrost Cycles Today** — Daily cycle counters (Aquarea, diagnostic)
+- **Heat Pump Status** — On/Off status of the heat pump unit (HWS, diagnostic)
+- **Operation Mode (raw)** — Raw, unconfirmed operation mode value (HWS, diagnostic, disabled by default)
 
 ### Zone Controls
 - **Zone Damper Position** — Slider control for zone damper (0–100%, in steps of 10)
@@ -80,7 +86,7 @@ This is a custom integration to control Panasonic Comfort Cloud devices in [Home
 - **Powerful Time** — Select powerful mode duration: on-30m, on-60m, on-90m, or off (Aquarea)
 
 ### Binary Sensors
-- **Error Status** — Indicates if the Aquarea device is in an error state, with error code and message attributes (Aquarea)
+- **Error Status** — Indicates if the Aquarea device is in an error state, with a raw fault status attribute (Aquarea)
 - **Defrost** — Indicates if the Aquarea device is in defrost mode (Aquarea)
 
 ### Buttons
@@ -187,10 +193,9 @@ data:
 
 ## Dependencies
 
-This integration uses the following Python packages:
+This integration uses the following Python package:
 
-- [`aio-panasonic-comfort-cloud`](https://github.com/sockless-coding/aio-panasonic-comfort-cloud) — For Panasonic air conditioners and heat pumps
-- [`aioaquarea`](https://github.com/cjaliaga/aioaquarea) — For Panasonic Aquarea heat pump systems
+- [`aio-panasonic-comfort-cloud`](https://github.com/sockless-coding/aio-panasonic-comfort-cloud) — For Panasonic air conditioners/heat pumps, Aquarea air-to-water heat pumps, and standalone HWS hot water tanks
 
 ---
 

--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -142,9 +142,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .panasonic import async_setup_panasonic
     data_coordinators, energy_coordinators = await async_setup_panasonic(hass, entry)
 
-    # Set up Aquarea slice (if there are unknown devices)
+    # Set up Aquarea slice
     from .aquarea import async_setup_aquarea
     aquarea_coordinators = await async_setup_aquarea(hass, entry, api)
+
+    # Set up HWS slice
+    from .hws import async_setup_hws
+    hws_coordinators = await async_setup_hws(hass, entry, api)
 
     integration = await async_get_integration(hass, DOMAIN)
     _LOGGER.info(STARTUP, integration.version)

--- a/custom_components/panasonic_cc/aquarea/__init__.py
+++ b/custom_components/panasonic_cc/aquarea/__init__.py
@@ -4,23 +4,19 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from aio_panasonic_comfort_cloud import ApiClient
-from aioaquarea import Client as AquareaApiClient
-from aioaquarea.data import DeviceInfo as AquareaDeviceInfo
+from aio_panasonic_comfort_cloud import ApiClient, PanasonicDeviceInfo
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from ..const import (
-    CONF_DEVICE_FETCH_INTERVAL,
-    DEFAULT_DEVICE_FETCH_INTERVAL,
+    CONF_ENABLE_DAILY_ENERGY_SENSOR,
+    DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
     DOMAIN,
+    MANUFACTURER,
 )
-from .const import AQUAREA_COORDINATORS
-from .coordinator import AquareaDeviceCoordinator
+from .const import AQUAREA_COORDINATORS, AQUAREA_ENERGY_COORDINATORS
+from .coordinator import AquareaConsumptionCoordinator, AquareaDeviceCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,45 +37,42 @@ async def async_setup_aquarea(
     entry: ConfigEntry,
     panasonic_api: ApiClient,
 ) -> list[AquareaDeviceCoordinator]:
-    """Set up Aquarea devices: create API client, coordinators, and register devices."""
-    if not panasonic_api.has_unknown_devices:
+    """Set up Aquarea devices: build coordinators from the shared ApiClient session and register devices."""
+    aquarea_devices = panasonic_api.aquarea_devices
+    if not aquarea_devices:
         hass.data[DOMAIN][AQUAREA_COORDINATORS] = []
+        hass.data[DOMAIN][AQUAREA_ENERGY_COORDINATORS] = []
         return []
 
-    username = entry.data[CONF_USERNAME]
-    password = entry.data[CONF_PASSWORD]
     config = {**entry.data, **entry.options}
-
-    client = async_get_clientsession(hass)
-
-    try:
-        aquarea_api = AquareaApiClient(client, username, password)
-        await aquarea_api.login()
-        aquarea_devices = await aquarea_api.get_devices()
-    except Exception as exc:
-        _LOGGER.warning("Failed to setup Aquarea devices: %s", exc, exc_info=True)
-        hass.data[DOMAIN][AQUAREA_COORDINATORS] = []
-        return []
+    enable_daily_energy_sensor = entry.options.get(
+        CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR
+    )
 
     aquarea_coordinators: list[AquareaDeviceCoordinator] = []
-    aquarea_coordinators_uninitialized: list[tuple[AquareaDeviceCoordinator, AquareaDeviceInfo]] = []
+    energy_coordinators: list[AquareaConsumptionCoordinator] = []
+    aquarea_coordinators_uninitialized: list[tuple[AquareaDeviceCoordinator, PanasonicDeviceInfo]] = []
 
-    for aquarea_device in aquarea_devices:
+    for device_info in aquarea_devices:
         try:
             aquarea_coordinator = AquareaDeviceCoordinator(
-                hass, config, aquarea_api, aquarea_device
+                hass, config, panasonic_api, device_info
             )
-            aquarea_coordinators_uninitialized.append((aquarea_coordinator, aquarea_device))
+            aquarea_coordinators_uninitialized.append((aquarea_coordinator, device_info))
+            if enable_daily_energy_sensor:
+                energy_coordinators.append(
+                    AquareaConsumptionCoordinator(hass, config, panasonic_api, device_info)
+                )
         except Exception as exc:
             _LOGGER.warning(
                 "Failed to create coordinator for Aquarea device %s: %s",
-                aquarea_device.name,
+                device_info.name,
                 exc,
                 exc_info=True,
             )
 
     # Refresh all Aquarea coordinators in parallel
-    async def _init_aquarea(coordinator: AquareaDeviceCoordinator, device_info: AquareaDeviceInfo) -> None:
+    async def _init_aquarea(coordinator: AquareaDeviceCoordinator, device_info: PanasonicDeviceInfo) -> None:
         try:
             await coordinator.async_config_entry_first_refresh()
             aquarea_coordinators.append(coordinator)
@@ -97,6 +90,7 @@ async def async_setup_aquarea(
     )
 
     hass.data[DOMAIN][AQUAREA_COORDINATORS] = aquarea_coordinators
+    hass.data[DOMAIN][AQUAREA_ENERGY_COORDINATORS] = energy_coordinators
 
     # Register devices in device registry
     device_registry = dr.async_get(hass)
@@ -104,11 +98,17 @@ async def async_setup_aquarea(
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, coordinator.device_id)},
-            name=coordinator.device.device_name,
-            manufacturer=coordinator.device.manufacturer,
-            model="",
-            sw_version=coordinator.device.firmware_version,
+            name=coordinator._device_info.name,
+            manufacturer=MANUFACTURER,
+            model=coordinator._device_info.model,
+            sw_version=coordinator.api_client.app_version,
         )
+
+    # Refresh energy coordinators (best-effort — failures shouldn't block device setup)
+    await asyncio.gather(
+        *(energy.async_config_entry_first_refresh() for energy in energy_coordinators),
+        return_exceptions=True,
+    )
 
     return aquarea_coordinators
 

--- a/custom_components/panasonic_cc/aquarea/base.py
+++ b/custom_components/panasonic_cc/aquarea/base.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import AquareaDeviceCoordinator
+from .coordinator import AquareaConsumptionCoordinator, AquareaDeviceCoordinator
 
 
 class AquareaDataEntity(CoordinatorEntity[AquareaDeviceCoordinator]):
@@ -14,6 +14,33 @@ class AquareaDataEntity(CoordinatorEntity[AquareaDeviceCoordinator]):
     _attr_has_entity_name = True
 
     def __init__(self, coordinator: AquareaDeviceCoordinator, key: str) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_translation_key = key
+        self._attr_unique_id = f"{coordinator.device_id}-{key}"
+        self._attr_device_info = self.coordinator.device_info
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is added to hass."""
+        await super().async_added_to_hass()
+        self._async_update_attrs()
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        self.async_write_ha_state()
+
+    @abstractmethod
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the entity."""
+
+
+class AquareaEnergyEntity(CoordinatorEntity[AquareaConsumptionCoordinator]):
+    """Base class for Aquarea energy consumption entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: AquareaConsumptionCoordinator, key: str) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
         self._attr_translation_key = key

--- a/custom_components/panasonic_cc/aquarea/binary_sensor.py
+++ b/custom_components/panasonic_cc/aquarea/binary_sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-import aioaquarea
+from aio_panasonic_comfort_cloud.constants import AquareaDeviceModeStatus
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -69,16 +69,14 @@ class AquareaStatusBinarySensor(AquareaDataEntity, BinarySensorEntity):
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the binary sensor."""
-        self._attr_is_on = self.coordinator.device.is_on_error
+        self._attr_is_on = self.coordinator.device.parameters.is_on_error
 
     @property
     def extra_state_attributes(self) -> dict:
         """Return extra state attributes."""
-        if self.coordinator.device.current_error is not None:
-            return {
-                "error_code": self.coordinator.device.current_error.error_code,
-                "error_message": self.coordinator.device.current_error.error_message,
-            }
+        fault_status = self.coordinator.device.parameters.fault_status
+        if fault_status:
+            return {"fault_status": fault_status}
         return {}
 
 
@@ -98,6 +96,6 @@ class AquareaDefrostBinarySensor(AquareaDataEntity, BinarySensorEntity):
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the binary sensor."""
-        is_defrosting = self.coordinator.device.device_mode_status is aioaquarea.DeviceModeStatus.DEFROST
+        is_defrosting = self.coordinator.device.parameters.device_mode_status is AquareaDeviceModeStatus.Defrost
         self._attr_is_on = is_defrosting
         self._attr_icon = "mdi:snowflake-melt" if is_defrosting else "mdi:snowflake-off"

--- a/custom_components/panasonic_cc/aquarea/button.py
+++ b/custom_components/panasonic_cc/aquarea/button.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import aioaquarea
+from aio_panasonic_comfort_cloud.constants import AquareaDeviceModeStatus
 
 from homeassistant.core import HomeAssistant, cached_property
 from homeassistant.components.button import ButtonEntity
@@ -39,10 +39,10 @@ class AquareaDefrostButton(ButtonEntity):
         """Request to start the defrost process."""
         _LOGGER.debug(
             "Requesting defrost for device %s",
-            self._coordinator.device.device_id,
+            self._coordinator.device_id,
         )
-        if self._coordinator.device.device_mode_status is not aioaquarea.DeviceModeStatus.DEFROST:
-            await self._coordinator.device.request_defrost()
+        if self._coordinator.device.parameters.device_mode_status is not AquareaDeviceModeStatus.Defrost:
+            await self._coordinator.api_client.request_aquarea_defrost(self._coordinator.info)
 
 
 async def async_setup_entry(

--- a/custom_components/panasonic_cc/aquarea/climate.py
+++ b/custom_components/panasonic_cc/aquarea/climate.py
@@ -17,14 +17,14 @@ from homeassistant.components.climate.const import ClimateEntityFeature
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 
-from aioaquarea import (
-    ExtendedOperationMode as AquareaExtendedOperationMode,
-    OperationStatus as AquareaZoneOperationStatus,
-    DeviceAction as AquareaDeviceAction,
-    UpdateOperationMode as AquareaUpdateOperationMode,
-    SpecialStatus as AquareaSpecialStatus,
-    DeviceDirection as AquareaDeviceDirection,
+from aio_panasonic_comfort_cloud.constants import (
+    AquareaOperationMode,
+    AquareaOperationStatus,
+    AquareaUpdateOperationMode,
+    AquareaSpecialStatus,
+    AquareaDeviceDirection,
 )
+from aio_panasonic_comfort_cloud.models.aquarea import AquareaZoneStatus
 
 from ..const import DOMAIN, PRESET_ECO, PRESET_NONE
 from .base import AquareaDataEntity
@@ -34,11 +34,19 @@ from .const import AQUAREA_COORDINATORS, AQUAREA_CLIMATE_DELAY_SHORT, AQUAREA_CL
 _LOGGER = logging.getLogger(__name__)
 
 AQUAREA_SPECIAL_STATUS_LOOKUP: dict[str, AquareaSpecialStatus | None] = {
-    PRESET_ECO: AquareaSpecialStatus.ECO,
-    "comfort": AquareaSpecialStatus.COMFORT,
+    PRESET_ECO: AquareaSpecialStatus.Eco,
+    "comfort": AquareaSpecialStatus.Comfort,
     PRESET_NONE: None,
 }
 AQUAREA_SPECIAL_STATUS_REVERSE_LOOKUP = {v: k for k, v in AQUAREA_SPECIAL_STATUS_LOOKUP.items()}
+
+
+def zone_supports_special_status(zone: AquareaZoneStatus) -> bool:
+    """Whether this zone reports Eco/Comfort setpoint offsets at all."""
+    return any(
+        value is not None
+        for value in (zone.eco_heat, zone.eco_cool, zone.comfort_heat, zone.comfort_cool)
+    )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -49,32 +57,22 @@ class AquareaClimateEntityDescription(ClimateEntityDescription):
 
 
 def convert_mode_and_status_to_hvac_mode(
-    mode: AquareaExtendedOperationMode,
-    zone_status: AquareaZoneOperationStatus,
+    mode: AquareaOperationMode,
+    zone_status: AquareaOperationStatus,
 ) -> HVACMode:
     """Convert mode and status to HVAC mode."""
-    if zone_status == AquareaZoneOperationStatus.OFF:
+    if zone_status == AquareaOperationStatus.Off:
         return HVACMode.OFF
     match mode:
-        case AquareaExtendedOperationMode.HEAT:
+        case AquareaOperationMode.Heat:
             return HVACMode.HEAT
-        case AquareaExtendedOperationMode.COOL:
+        case AquareaOperationMode.Cool:
             return HVACMode.COOL
-        case AquareaExtendedOperationMode.AUTO_COOL:
+        case AquareaOperationMode.AutoCool:
             return HVACMode.HEAT_COOL
-        case AquareaExtendedOperationMode.AUTO_HEAT:
+        case AquareaOperationMode.AutoHeat:
             return HVACMode.HEAT_COOL
     return HVACMode.OFF
-
-
-def convert_aquarea_action_to_hvac_action(action: AquareaDeviceAction) -> HVACAction:
-    """Convert device action to HVAC action."""
-    match action:
-        case AquareaDeviceAction.COOLING:
-            return HVACAction.COOLING
-        case AquareaDeviceAction.HEATING:
-            return HVACAction.HEATING
-    return HVACAction.IDLE
 
 
 def convert_hvac_mode_to_aquarea_operation_mode(
@@ -83,19 +81,19 @@ def convert_hvac_mode_to_aquarea_operation_mode(
     """Convert HVAC mode to update operation mode."""
     match mode:
         case HVACMode.HEAT:
-            return AquareaUpdateOperationMode.HEAT
+            return AquareaUpdateOperationMode.Heat
         case HVACMode.COOL:
-            return AquareaUpdateOperationMode.COOL
+            return AquareaUpdateOperationMode.Cool
         case HVACMode.HEAT_COOL:
-            return AquareaUpdateOperationMode.AUTO
-    return AquareaUpdateOperationMode.OFF
+            return AquareaUpdateOperationMode.Auto
+    return AquareaUpdateOperationMode.Off
 
 
 def _get_hvac_action_from_device_direction(
     direction: AquareaDeviceDirection, hvac_mode: HVACMode
 ) -> HVACAction:
     """Convert device direction to HVAC action, using hvac_mode for context."""
-    if direction == AquareaDeviceDirection.PUMP:
+    if direction == AquareaDeviceDirection.Pump:
         if hvac_mode == HVACMode.HEAT:
             return HVACAction.HEATING
         if hvac_mode == HVACMode.COOL:
@@ -119,7 +117,7 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
         super().__init__(coordinator, description.key)
         self.entity_description = description
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
-        zone = self.coordinator.device.zones.get(description.zone_id)
+        zone = self.coordinator.device.parameters.get_zone(description.zone_id)
         self._attr_name = zone.name if zone else None
         self._attr_unique_id = f"{super().unique_id}_climate_{description.zone_id}"
         self._attr_supported_features = (
@@ -127,15 +125,15 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
             | ClimateEntityFeature.TURN_OFF
             | ClimateEntityFeature.TURN_ON
         )
-        if self.coordinator.device.support_special_status:
+        if zone is not None and zone_supports_special_status(zone):
             self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
             self._attr_preset_modes = list(AQUAREA_SPECIAL_STATUS_LOOKUP.keys())
             self._attr_preset_mode = AQUAREA_SPECIAL_STATUS_REVERSE_LOOKUP.get(
-                self.coordinator.device.special_status, PRESET_NONE
+                self.coordinator.device.parameters.special_status, PRESET_NONE
             )
         self._attr_precision = PRECISION_WHOLE
         self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
-        if zone and zone.cool_mode:
+        if zone and zone.supports_cooling:
             self._attr_hvac_modes.extend([HVACMode.COOL, HVACMode.HEAT_COOL])
         self._attr_hvac_mode = HVACMode.OFF
 
@@ -147,52 +145,52 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
 
     def _async_update_attrs(self) -> None:
         """Update attributes."""
-        device = self.coordinator.device
-        zone = device.zones.get(self.entity_description.zone_id)
+        params = self.coordinator.device.parameters
+        zone = params.get_zone(self.entity_description.zone_id)
 
-        if zone is None or zone.operation_status == AquareaZoneOperationStatus.OFF:
+        if zone is None or zone.operation_status == AquareaOperationStatus.Off:
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_hvac_action = HVACAction.OFF
             self._attr_target_temperature = None
             self._attr_min_temp = 5
             self._attr_max_temp = 65
-            if device.support_special_status:
+            if zone is not None and zone_supports_special_status(zone):
                 self._attr_preset_mode = AQUAREA_SPECIAL_STATUS_REVERSE_LOOKUP.get(
-                    device.special_status, PRESET_NONE
+                    params.special_status, PRESET_NONE
                 )
             return
 
         self._attr_hvac_mode = convert_mode_and_status_to_hvac_mode(
-            device.mode, zone.operation_status
+            params.operation_mode, zone.operation_status
         )
 
         self._attr_hvac_action = _get_hvac_action_from_device_direction(
-            device.current_direction, self._attr_hvac_mode
+            params.direction, self._attr_hvac_mode
         )
 
         self._attr_current_temperature = zone.temperature
 
-        if device.mode in (
-            AquareaExtendedOperationMode.HEAT,
-            AquareaExtendedOperationMode.AUTO_HEAT,
+        if params.operation_mode in (
+            AquareaOperationMode.Heat,
+            AquareaOperationMode.AutoHeat,
         ):
-            self._attr_target_temperature = zone.heat_target_temperature
+            self._attr_target_temperature = zone.heat_set
             self._attr_min_temp = zone.heat_min if zone.heat_min is not None else 5
             self._attr_max_temp = zone.heat_max if zone.heat_max is not None else 65
         else:
-            self._attr_target_temperature = zone.cool_target_temperature
+            self._attr_target_temperature = zone.cool_set
             self._attr_min_temp = zone.cool_min if zone.cool_min is not None else 5
             self._attr_max_temp = zone.cool_max if zone.cool_max is not None else 65
 
         hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
-        if zone.cool_mode:
+        if zone.supports_cooling:
             hvac_modes.append(HVACMode.COOL)
             hvac_modes.append(HVACMode.HEAT_COOL)
         self._attr_hvac_modes = hvac_modes
 
-        if device.support_special_status:
+        if zone_supports_special_status(zone):
             self._attr_preset_mode = AQUAREA_SPECIAL_STATUS_REVERSE_LOOKUP.get(
-                device.special_status, PRESET_NONE
+                params.special_status, PRESET_NONE
             )
 
     async def _schedule_refresh(self, delay: float = AQUAREA_CLIMATE_DELAY_SHORT) -> None:
@@ -203,17 +201,19 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
         except Exception:
             _LOGGER.exception(
                 "Delayed refresh failed for device %s",
-                self.coordinator.device.device_id,
+                self.coordinator.device_id,
             )
 
     async def async_turn_on(self) -> None:
-        """Turn the climate entity on."""
-        await self.coordinator.device.turn_on()
-        device = self.coordinator.device
-        zone = device.zones.get(self.entity_description.zone_id)
-        if zone and zone.operation_status != AquareaZoneOperationStatus.OFF:
+        """Turn the climate entity's zone on."""
+        await self.coordinator.api_client.set_aquarea_zone_operation_status(
+            self.coordinator.info, self.entity_description.zone_id, AquareaOperationStatus.On
+        )
+        params = self.coordinator.device.parameters
+        zone = params.get_zone(self.entity_description.zone_id)
+        if zone is not None:
             self._attr_hvac_mode = convert_mode_and_status_to_hvac_mode(
-                device.mode, zone.operation_status
+                params.operation_mode, AquareaOperationStatus.On
             )
         else:
             self._attr_hvac_mode = HVACMode.HEAT
@@ -221,8 +221,10 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
         self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))
 
     async def async_turn_off(self) -> None:
-        """Turn the climate entity off."""
-        await self.coordinator.device.turn_off()
+        """Turn the climate entity's zone off."""
+        await self.coordinator.api_client.set_aquarea_zone_operation_status(
+            self.coordinator.info, self.entity_description.zone_id, AquareaOperationStatus.Off
+        )
         self._attr_hvac_mode = HVACMode.OFF
         self.async_write_ha_state()
         self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))
@@ -233,9 +235,11 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
             await self.async_turn_off()
             return
         operation_mode = convert_hvac_mode_to_aquarea_operation_mode(hvac_mode)
-        await self.coordinator.device.set_mode(
-            mode=operation_mode,
-            zone_id=self.entity_description.zone_id,
+        await self.coordinator.api_client.set_aquarea_operation_mode(
+            self.coordinator.info, operation_mode
+        )
+        await self.coordinator.api_client.set_aquarea_zone_operation_status(
+            self.coordinator.info, self.entity_description.zone_id, AquareaOperationStatus.On
         )
         self._attr_hvac_mode = hvac_mode
         self.async_write_ha_state()
@@ -246,9 +250,13 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
         state_changed = False
         if ATTR_TEMPERATURE in kwargs:
             target_temp = kwargs[ATTR_TEMPERATURE]
-            await self.coordinator.device.set_temperature(
-                temperature=target_temp,
-                zone_id=self.entity_description.zone_id,
+            operation_mode = self.coordinator.device.parameters.operation_mode
+            mode = "heat" if operation_mode in (AquareaOperationMode.Heat, AquareaOperationMode.AutoHeat) else "cool"
+            await self.coordinator.api_client.set_aquarea_zone_temperature(
+                self.coordinator.info,
+                self.entity_description.zone_id,
+                int(target_temp),
+                mode=mode,
             )
             self._attr_target_temperature = target_temp
             state_changed = True
@@ -260,18 +268,18 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        if not self.coordinator.device.support_special_status:
-            return
         if self.preset_modes is None or preset_mode not in self.preset_modes:
             raise ValueError(f"Unsupported preset_mode '{preset_mode}'")
         special_status = AQUAREA_SPECIAL_STATUS_LOOKUP.get(preset_mode)
         _LOGGER.debug(
             "Setting preset mode of device %s to %s (special_status=%s)",
-            self.coordinator.device.device_id,
+            self.coordinator.device_id,
             preset_mode,
             special_status,
         )
-        await self.coordinator.device.set_special_status(special_status)
+        await self.coordinator.api_client.set_aquarea_special_status(
+            self.coordinator.device, special_status
+        )
         self._attr_preset_mode = preset_mode
         self.async_write_ha_state()
         self.hass.async_create_task(self._schedule_refresh(AQUAREA_CLIMATE_DELAY_LONG))
@@ -286,18 +294,15 @@ async def async_setup_entry(
     entities = []
     aquarea_coordinators = hass.data[DOMAIN][AQUAREA_COORDINATORS]
     for aquarea_coordinator in aquarea_coordinators:
-        for zone_id in aquarea_coordinator.device.zones:
-            zone = aquarea_coordinator.device.zones.get(zone_id)
-            if zone is None:
-                continue
+        for zone in aquarea_coordinator.device.parameters.zones:
             entities.append(
                 AquareaClimateEntity(
                     aquarea_coordinator,
                     AquareaClimateEntityDescription(
-                        zone_id=zone_id,
+                        zone_id=zone.id,
                         name=zone.name,
-                        key=f"zone-{zone_id}-climate",
-                        translation_key=f"zone-{zone_id}-climate",
+                        key=f"zone-{zone.id}-climate",
+                        translation_key=f"zone-{zone.id}-climate",
                     ),
                 )
             )

--- a/custom_components/panasonic_cc/aquarea/const.py
+++ b/custom_components/panasonic_cc/aquarea/const.py
@@ -1,6 +1,7 @@
 """Constants for Aquarea devices."""
 
 AQUAREA_COORDINATORS = "aquarea_coordinators"
+AQUAREA_ENERGY_COORDINATORS = "aquarea_energy_coordinators"
 
 AQUAREA_SWITCH_DELAY = 10.0
 AQUAREA_SELECT_DELAY = 10.0

--- a/custom_components/panasonic_cc/aquarea/coordinator.py
+++ b/custom_components/panasonic_cc/aquarea/coordinator.py
@@ -1,7 +1,7 @@
 """Coordinators for Aquarea devices."""
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from aiohttp import ClientResponseError
 from homeassistant.components.persistent_notification import async_create
@@ -9,11 +9,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.entity import DeviceInfo
 
-from aioaquarea import (
-    Client as AquareaApiClient,
-    Device as AquareaDevice,
+from aio_panasonic_comfort_cloud import (
+    ApiClient,
+    AquareaDevice,
+    AquareaConsumption,
+    PanasonicDeviceInfo,
+    constants,
 )
-from aioaquarea.data import DeviceInfo as AquareaDeviceInfo
 
 from ..const import (
     DEFAULT_DEVICE_FETCH_INTERVAL,
@@ -21,6 +23,7 @@ from ..const import (
     CONF_DEVICE_FETCH_INTERVAL,
     CONF_ENERGY_FETCH_INTERVAL,
     DOMAIN,
+    MANUFACTURER,
     NOTIFICATION_AUTH_EXPIRED,
 )
 from ..error_handler import classify_error, FriendlyError, ErrorCategory
@@ -57,8 +60,8 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
         self,
         hass: HomeAssistant,
         config: dict,
-        api_client: AquareaApiClient,
-        device_info: AquareaDeviceInfo,
+        api_client: ApiClient,
+        device_info: PanasonicDeviceInfo,
     ) -> None:
         """Initialize the coordinator."""
         self._base_interval = config.get(
@@ -74,7 +77,6 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
         self._device_info = device_info
         self._device: AquareaDevice | None = None
         self._update_id = 0
-        self._config = dict(config)
         self._refresh_task: asyncio.Task | None = None
         self._consecutive_failures = 0
         self._auth_failed = False
@@ -105,49 +107,64 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
         return self._device
 
     @property
-    def api_client(self) -> AquareaApiClient:
+    def api_client(self) -> ApiClient:
         """Return the API client."""
         return self._api_client
 
     @property
+    def info(self) -> PanasonicDeviceInfo:
+        """Return the raw device info used for ApiClient.set_aquarea_* calls."""
+        return self._device_info
+
+    @property
     def device_id(self) -> str:
-        """Return the device ID."""
-        return self.device.device_id
+        """Return the device ID.
+
+        Uses the raw ``deviceGuid`` (``PanasonicDeviceInfo.guid``), not the
+        hashed ``.id`` other coordinators use — this is what the previous
+        aioaquarea-based Aquarea slice keyed its entities/device registry
+        entries on (its own ``device_id`` was read straight off
+        ``deviceGuid``, unhashed), so existing installs keep the same
+        unique IDs across this migration instead of getting orphaned.
+        """
+        return self._device_info.guid or self._device_info.id
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.device_id)},
-            manufacturer=self.device.manufacturer,
-            model=self.device.model or "",
-            name=self.device.device_name,
-            sw_version=self.device.firmware_version,
+            manufacturer=MANUFACTURER,
+            model=self._device_info.model,
+            name=self._device_info.name,
+            sw_version=self._api_client.app_version,
         )
 
     def _device_state_hash(self) -> int:
         """Compute a hash of the device state for change detection."""
         if self._device is None:
             return 0
+        params = self._device.parameters
         state = (
-            self._device.mode,
-            self._device.current_direction,
-            self._device.special_status,
-            self._device.force_dhw,
-            self._device.force_heater,
-            self._device.quiet_mode,
-            self._device.powerful_time,
-            self._device.tank.target_temperature if self._device.tank else None,
-            self._device.tank.temperature if self._device.tank else None,
-            self._device.tank.operation_status if self._device.tank else None,
+            params.operation_status,
+            params.operation_mode,
+            params.direction,
+            params.special_status,
+            params.force_dhw,
+            params.force_heater,
+            params.quiet_mode,
+            params.powerful_time,
+            params.tank.heat_set if params.tank else None,
+            params.tank.temperature if params.tank else None,
+            params.tank.operation_status if params.tank else None,
             tuple(
                 (
-                    z.operation_status,
-                    z.temperature,
-                    z.heat_target_temperature,
-                    z.cool_target_temperature,
+                    zone.operation_status,
+                    zone.temperature,
+                    zone.heat_set,
+                    zone.cool_set,
                 )
-                for z in self._device.zones.values()
+                for zone in params.zones
             ),
         )
         return hash(state)
@@ -158,27 +175,26 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
             raise UpdateFailed("Authentication failed — coordinator disabled")
 
         try:
-            self._device = await self._api_client.get_device(
-                device_info=self._device_info,
-                consumption_refresh_interval=timedelta(
-                    seconds=self._config.get(CONF_ENERGY_FETCH_INTERVAL, DEFAULT_ENERGY_FETCH_INTERVAL)
-                ),
-            )
-            await self._device.refresh_data()
-            current_hash = self._device_state_hash()
-            if current_hash != self._last_device_state_hash:
-                self._last_device_state_hash = current_hash
-                self._update_id += 1
+            if self._device is None:
+                self._device = await self._api_client.get_aquarea_device(self._device_info)
+                self._update_id = 1
+                self._last_device_state_hash = self._device_state_hash()
                 self._reset_backoff()
                 return self._update_id
+            if await self._api_client.try_update_aquarea_device(self._device):
+                current_hash = self._device_state_hash()
+                if current_hash != self._last_device_state_hash:
+                    self._last_device_state_hash = current_hash
+                    self._update_id += 1
+                    self._reset_backoff()
+                    return self._update_id
             self._reset_backoff()
         except Exception as err:
             if _is_auth_error(err):
                 self._auth_failed = True
-                device_name = self.device.device_name if self._device else self._device_info.name
                 _LOGGER.error(
                     "%s Authentication has expired or is invalid. Please re-authenticate by removing and re-adding the integration.",
-                    device_name,
+                    self._device_info.name,
                     exc_info=True,
                 )
                 _create_auth_expired_notification(self.hass)
@@ -244,3 +260,151 @@ class AquareaDeviceCoordinator(DataUpdateCoordinator[int]):
                 self._refresh_task = None
 
         self._refresh_task = self.hass.async_create_task(_delayed_refresh())
+
+
+class AquareaConsumptionCoordinator(DataUpdateCoordinator[int]):
+    """Aquarea energy consumption data coordinator (today's heat/cool/tank consumption+cost)."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config: dict,
+        api_client: ApiClient,
+        device_info: PanasonicDeviceInfo,
+    ) -> None:
+        """Initialize the coordinator."""
+        self._base_interval = config.get(
+            CONF_ENERGY_FETCH_INTERVAL, DEFAULT_ENERGY_FETCH_INTERVAL
+        )
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"Aquarea Energy Coordinator ({device_info.name})",
+            update_interval=timedelta(seconds=self._base_interval),
+        )
+        self._api_client = api_client
+        self._device_info = device_info
+        self._consumption: AquareaConsumption | None = None
+        self._update_id = 0
+        self._consecutive_failures = 0
+        self._auth_failed = False
+        self._last_error: FriendlyError | None = None
+
+    @property
+    def last_error(self) -> FriendlyError | None:
+        """Return the last error that occurred."""
+        return self._last_error
+
+    @property
+    def connection_status(self) -> str:
+        """Return the current connection status."""
+        if self._auth_failed:
+            return "authentication_error"
+        if self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            return "disconnected"
+        if self._consecutive_failures > 0:
+            return "degraded"
+        return "connected"
+
+    @property
+    def api_client(self) -> ApiClient:
+        """Return the API client."""
+        return self._api_client
+
+    @property
+    def device_id(self) -> str:
+        """Return the device ID.
+
+        Uses ``.guid``, matching ``AquareaDeviceCoordinator.device_id`` —
+        keeps these energy entities attached to the same HA device entry as
+        the rest of the Aquarea unit's entities.
+        """
+        return self._device_info.guid or self._device_info.id
+
+    @property
+    def consumption(self) -> AquareaConsumption | None:
+        """Return today's consumption data."""
+        return self._consumption
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.device_id)},
+            manufacturer=MANUFACTURER,
+            model=self._device_info.model,
+            name=self._device_info.name,
+            sw_version=self._api_client.app_version,
+        )
+
+    async def _async_update_data(self) -> int:
+        """Fetch today's consumption data from the API."""
+        if self._auth_failed:
+            raise UpdateFailed("Authentication failed — coordinator disabled")
+
+        today = datetime.now().strftime("%Y%m%d")
+        try:
+            entries = await self._api_client.async_get_aquarea_consumption(
+                self._device_info, constants.AquareaDataMode.Month, today
+            )
+            todays_entry = next(
+                (entry for entry in entries if entry.data_time == today), None
+            )
+            if todays_entry is not None:
+                self._consumption = todays_entry
+                self._update_id += 1
+            self._reset_backoff()
+        except Exception as err:
+            if _is_auth_error(err):
+                self._auth_failed = True
+                _LOGGER.error(
+                    "%s Authentication has expired or is invalid. Please re-authenticate by removing and re-adding the integration.",
+                    self._device_info.name,
+                    exc_info=True,
+                )
+                _create_auth_expired_notification(self.hass)
+                raise UpdateFailed("Authentication failed — coordinator disabled") from err
+            self._handle_failure(err)
+            friendly = classify_error(err)
+            raise UpdateFailed(f"{friendly.title}: {friendly.message}") from err
+        return self._update_id
+
+    def _reset_backoff(self) -> None:
+        """Reset circuit breaker and restore base polling interval."""
+        if self._consecutive_failures > 0:
+            _LOGGER.debug(
+                "%s Energy API recovered after %d consecutive failure(s)",
+                self._device_info.name,
+                self._consecutive_failures,
+            )
+        self._consecutive_failures = 0
+        self._last_error = None
+        self.update_interval = timedelta(seconds=self._base_interval)
+
+    def _handle_failure(self, err: Exception | None = None) -> None:
+        """Handle API failure with exponential backoff."""
+        self._consecutive_failures += 1
+        new_interval = min(
+            self._base_interval * (BACKOFF_MULTIPLIER ** self._consecutive_failures),
+            MAX_UPDATE_INTERVAL,
+        )
+        self.update_interval = timedelta(seconds=new_interval)
+        if err is not None:
+            self._last_error = classify_error(err)
+            _LOGGER.warning(
+                "%s Energy API failure %d/%d — %s: %s — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                self._last_error.title,
+                self._last_error.message,
+                new_interval,
+            )
+        else:
+            _LOGGER.warning(
+                "%s Energy API failure %d/%d — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                new_interval,
+            )

--- a/custom_components/panasonic_cc/aquarea/select.py
+++ b/custom_components/panasonic_cc/aquarea/select.py
@@ -5,8 +5,7 @@ import asyncio
 import logging
 from typing import Any
 
-import aioaquarea
-from aioaquarea import PowerfulTime, QuietMode
+from aio_panasonic_comfort_cloud.constants import AquareaPowerfulTime, AquareaQuietMode
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -20,19 +19,19 @@ from .const import AQUAREA_COORDINATORS, AQUAREA_SELECT_DELAY
 _LOGGER = logging.getLogger(__name__)
 
 QUIET_MODE_LOOKUP = {
-    "level1": QuietMode.LEVEL1,
-    "level2": QuietMode.LEVEL2,
-    "level3": QuietMode.LEVEL3,
-    "off": QuietMode.OFF,
+    "level1": AquareaQuietMode.Level1,
+    "level2": AquareaQuietMode.Level2,
+    "level3": AquareaQuietMode.Level3,
+    "off": AquareaQuietMode.Off,
 }
 
 QUIET_MODE_REVERSE_LOOKUP = {v: k for k, v in QUIET_MODE_LOOKUP.items()}
 
 POWERFUL_TIME_LOOKUP = {
-    "on-30m": PowerfulTime.ON_30MIN,
-    "on-60m": PowerfulTime.ON_60MIN,
-    "on-90m": PowerfulTime.ON_90MIN,
-    "off": PowerfulTime.OFF,
+    "on-30m": AquareaPowerfulTime.On30Min,
+    "on-60m": AquareaPowerfulTime.On60Min,
+    "on-90m": AquareaPowerfulTime.On90Min,
+    "off": AquareaPowerfulTime.Off,
 }
 
 POWERFUL_TIME_REVERSE_LOOKUP = {v: k for k, v in POWERFUL_TIME_LOOKUP.items()}
@@ -55,7 +54,7 @@ class AquareaQuietModeSelect(AquareaDataEntity, SelectEntity):
         if self._optimistic_option is not None:
             return self._optimistic_option
         return QUIET_MODE_REVERSE_LOOKUP.get(
-            self.coordinator.device.quiet_mode, "off"
+            self.coordinator.device.parameters.quiet_mode, "off"
         )
 
     async def _schedule_refresh(self, delay: float = AQUAREA_SELECT_DELAY) -> None:
@@ -68,17 +67,17 @@ class AquareaQuietModeSelect(AquareaDataEntity, SelectEntity):
         """Change the selected option."""
         if (quiet_mode := QUIET_MODE_LOOKUP.get(option)) is None:
             return
-        if quiet_mode is self.coordinator.device.quiet_mode:
+        if quiet_mode is self.coordinator.device.parameters.quiet_mode:
             return
         _LOGGER.debug(
             "Setting Quiet Mode of device %s, from %s to %s",
-            self.coordinator.device.device_id,
-            str(self.coordinator.device.quiet_mode),
+            self.coordinator.device_id,
+            str(self.coordinator.device.parameters.quiet_mode),
             str(quiet_mode),
         )
         self._optimistic_option = option
         self.async_write_ha_state()
-        await self.coordinator.device.set_quiet_mode(quiet_mode)
+        await self.coordinator.api_client.set_aquarea_quiet_mode(self.coordinator.info, quiet_mode)
         self.hass.async_create_task(self._schedule_refresh())
 
     def _async_update_attrs(self) -> None:
@@ -108,7 +107,7 @@ class AquareaPowerfulTimeSelect(AquareaDataEntity, SelectEntity):
         if self._optimistic_option is not None:
             return self._optimistic_option
         return POWERFUL_TIME_REVERSE_LOOKUP.get(
-            self.coordinator.device.powerful_time, "off"
+            self.coordinator.device.parameters.powerful_time, "off"
         )
 
     async def _schedule_refresh(self, delay: float = AQUAREA_SELECT_DELAY) -> None:
@@ -121,17 +120,17 @@ class AquareaPowerfulTimeSelect(AquareaDataEntity, SelectEntity):
         """Change the selected option."""
         if (powerful_time := POWERFUL_TIME_LOOKUP.get(option)) is None:
             return
-        if powerful_time is self.coordinator.device.powerful_time:
+        if powerful_time is self.coordinator.device.parameters.powerful_time:
             return
         _LOGGER.debug(
             "Setting Powerful Time of device %s, from %s to %s",
-            self.coordinator.device.device_id,
-            str(self.coordinator.device.powerful_time),
+            self.coordinator.device_id,
+            str(self.coordinator.device.parameters.powerful_time),
             str(powerful_time),
         )
         self._optimistic_option = option
         self.async_write_ha_state()
-        await self.coordinator.device.set_powerful_time(powerful_time)
+        await self.coordinator.api_client.set_aquarea_powerful_time(self.coordinator.info, powerful_time)
         self.hass.async_create_task(self._schedule_refresh())
 
     def _async_update_attrs(self) -> None:

--- a/custom_components/panasonic_cc/aquarea/sensor.py
+++ b/custom_components/panasonic_cc/aquarea/sensor.py
@@ -5,7 +5,9 @@ from datetime import datetime
 import logging
 from typing import Any
 
-import aioaquarea
+from aio_panasonic_comfort_cloud import AquareaDevice
+from aio_panasonic_comfort_cloud.constants import AquareaDeviceDirection, AquareaDeviceModeStatus, AquareaOperationStatus, AquareaPumpDuty
+from aio_panasonic_comfort_cloud.models.aquarea import AquareaConsumption
 
 from homeassistant.const import UnitOfEnergy, UnitOfTemperature, EntityCategory
 from homeassistant.components.sensor import (
@@ -19,12 +21,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
-from aioaquarea import Device as AquareaDevice
-
 from ..const import DOMAIN
-from .base import AquareaDataEntity
-from .coordinator import AquareaDeviceCoordinator
-from .const import AQUAREA_COORDINATORS
+from .base import AquareaDataEntity, AquareaEnergyEntity
+from .coordinator import AquareaConsumptionCoordinator, AquareaDeviceCoordinator
+from .const import AQUAREA_COORDINATORS, AQUAREA_ENERGY_COORDINATORS
 from ..error_handler import ErrorCategory
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,8 +43,8 @@ AQUAREA_OUTSIDE_TEMPERATURE_DESCRIPTION = AquareaSensorEntityDescription(
     device_class=SensorDeviceClass.TEMPERATURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-    get_state=lambda device: device.temperature_outdoor,
-    is_available=lambda device: device.temperature_outdoor is not None,
+    get_state=lambda device: device.parameters.temperature_outdoor,
+    is_available=lambda device: device.parameters.temperature_outdoor is not None,
 )
 
 AQUAREA_TANK_TEMPERATURE_DESCRIPTION = AquareaSensorEntityDescription(
@@ -55,8 +55,8 @@ AQUAREA_TANK_TEMPERATURE_DESCRIPTION = AquareaSensorEntityDescription(
     device_class=SensorDeviceClass.TEMPERATURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-    get_state=lambda device: device.tank.temperature if device.tank is not None else None,
-    is_available=lambda device: device.tank is not None,
+    get_state=lambda device: device.parameters.tank.temperature if device.parameters.tank is not None else None,
+    is_available=lambda device: device.parameters.tank is not None,
 )
 
 AQUAREA_DIRECTION_DESCRIPTION = AquareaSensorEntityDescription(
@@ -64,7 +64,7 @@ AQUAREA_DIRECTION_DESCRIPTION = AquareaSensorEntityDescription(
     translation_key="direction",
     name="Direction",
     icon="mdi:compass",
-    get_state=lambda device: device.current_direction.name,
+    get_state=lambda device: device.parameters.direction.name,
     is_available=lambda device: True,
 )
 
@@ -73,112 +73,100 @@ AQUAREA_PUMP_STATUS_DESCRIPTION = AquareaSensorEntityDescription(
     translation_key="pump_status",
     name="Pump Status",
     icon="mdi:pump",
-    get_state=lambda device: "On" if device.pump_duty == 1 else "Off",
+    get_state=lambda device: "On" if device.parameters.pump_duty == AquareaPumpDuty.On else "Off",
     is_available=lambda device: True,
 )
 
 # Connection status sensor options
 AQUAREA_CONNECTION_STATUS_OPTIONS = ["connected", "degraded", "disconnected", "authentication_error"]
 
-# Energy consumption sensor descriptions for Aquarea
+# Energy consumption sensor descriptions for Aquarea, backed by AquareaConsumptionCoordinator
 @dataclass(frozen=True, kw_only=True)
 class AquareaEnergySensorEntityDescription(SensorEntityDescription):
     """Describes Aquarea energy sensor entity."""
-    consumption_type: aioaquarea.ConsumptionType
+    get_state: Callable[[AquareaConsumption], Any]
     exists_fn: Callable[[AquareaDeviceCoordinator], bool] = lambda _: True
 
 
-AQUAREA_ACCUMULATED_ENERGY_SENSORS = [
+AQUAREA_ENERGY_SENSORS = [
     AquareaEnergySensorEntityDescription(
-        key="heating_accumulated_energy_consumption",
-        translation_key="heating_accumulated_energy_consumption",
-        name="Heating Accumulated Consumption",
+        key="heating_energy_consumption_today",
+        translation_key="heating_energy_consumption_today",
+        name="Heating Consumption Today",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.HEAT,
+        get_state=lambda entry: entry.heat_consumption,
     ),
     AquareaEnergySensorEntityDescription(
-        key="cooling_accumulated_energy_consumption",
-        translation_key="cooling_accumulated_energy_consumption",
-        name="Cooling Accumulated Consumption",
+        key="cooling_energy_consumption_today",
+        translation_key="cooling_energy_consumption_today",
+        name="Cooling Consumption Today",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.COOL,
-        exists_fn=lambda coordinator: any(zone.cool_mode for zone in coordinator.device.zones.values()),
+        get_state=lambda entry: entry.cool_consumption,
+        exists_fn=lambda coordinator: any(zone.supports_cooling for zone in coordinator.device.parameters.zones),
     ),
     AquareaEnergySensorEntityDescription(
-        key="tank_accumulated_energy_consumption",
-        translation_key="tank_accumulated_energy_consumption",
-        name="Tank Accumulated Consumption",
+        key="tank_energy_consumption_today",
+        translation_key="tank_energy_consumption_today",
+        name="Tank Consumption Today",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.WATER_TANK,
-        exists_fn=lambda coordinator: coordinator.device.has_tank,
+        get_state=lambda entry: entry.tank_consumption,
+        exists_fn=lambda coordinator: coordinator.device.parameters.has_tank,
     ),
     AquareaEnergySensorEntityDescription(
-        key="accumulated_energy_consumption",
-        translation_key="accumulated_energy_consumption",
-        name="Accumulated Consumption",
+        key="energy_consumption_today",
+        translation_key="energy_consumption_today",
+        name="Consumption Today",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.TOTAL,
+        get_state=lambda entry: entry.total_consumption,
     ),
 ]
 
-AQUAREA_ENERGY_SENSORS = [
+# Cost sensors — a bonus the old aioaquarea-based sensors never had. Kept
+# diagnostic/disabled by default so they don't clutter the default entity list.
+AQUAREA_COST_SENSORS = [
     AquareaEnergySensorEntityDescription(
-        key="heating_energy_consumption",
-        translation_key="heating_energy_consumption",
-        name="Heating Consumption",
-        device_class=SensorDeviceClass.ENERGY,
+        key="heating_cost_today",
+        translation_key="heating_cost_today",
+        name="Heating Cost Today",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.HEAT,
+        entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        get_state=lambda entry: entry.heat_cost,
     ),
     AquareaEnergySensorEntityDescription(
-        key="tank_energy_consumption",
-        translation_key="tank_energy_consumption",
-        name="Tank Consumption",
-        device_class=SensorDeviceClass.ENERGY,
+        key="cooling_cost_today",
+        translation_key="cooling_cost_today",
+        name="Cooling Cost Today",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.WATER_TANK,
-        exists_fn=lambda coordinator: coordinator.device.has_tank,
+        entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        get_state=lambda entry: entry.cool_cost,
+        exists_fn=lambda coordinator: any(zone.supports_cooling for zone in coordinator.device.parameters.zones),
     ),
     AquareaEnergySensorEntityDescription(
-        key="cooling_energy_consumption",
-        translation_key="cooling_energy_consumption",
-        name="Cooling Consumption",
-        device_class=SensorDeviceClass.ENERGY,
+        key="tank_cost_today",
+        translation_key="tank_cost_today",
+        name="Tank Cost Today",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.COOL,
-        exists_fn=lambda coordinator: any(zone.cool_mode for zone in coordinator.device.zones.values()),
+        entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-    ),
-    AquareaEnergySensorEntityDescription(
-        key="energy_consumption",
-        translation_key="energy_consumption",
-        name="Consumption",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        suggested_display_precision=2,
-        consumption_type=aioaquarea.ConsumptionType.TOTAL,
-        entity_registry_enabled_default=False,
+        get_state=lambda entry: entry.tank_cost,
+        exists_fn=lambda coordinator: coordinator.device.parameters.has_tank,
     ),
 ]
 
@@ -198,7 +186,7 @@ AQUAREA_DAILY_COUNTERS = [
         device_class=SensorDeviceClass.ENUM,
         state_class=SensorStateClass.TOTAL,
         entity_category=EntityCategory.DIAGNOSTIC,
-        detector=lambda device: device.current_direction == aioaquarea.DeviceDirection.WATER,
+        detector=lambda device: device.parameters.direction == AquareaDeviceDirection.Water,
     ),
     AquareaDailyCounterEntityDescription(
         key="zone_cycles_today",
@@ -209,8 +197,8 @@ AQUAREA_DAILY_COUNTERS = [
         state_class=SensorStateClass.TOTAL,
         entity_category=EntityCategory.DIAGNOSTIC,
         detector=lambda device: (
-            device.current_direction == aioaquarea.DeviceDirection.PUMP
-            and any(zone.operation_status == aioaquarea.OperationStatus.ON for zone in device.zones.values())
+            device.parameters.direction == AquareaDeviceDirection.Pump
+            and any(zone.operation_status == AquareaOperationStatus.On for zone in device.parameters.zones)
         ),
     ),
     AquareaDailyCounterEntityDescription(
@@ -221,7 +209,7 @@ AQUAREA_DAILY_COUNTERS = [
         device_class=SensorDeviceClass.ENUM,
         state_class=SensorStateClass.TOTAL,
         entity_category=EntityCategory.DIAGNOSTIC,
-        detector=lambda device: device.device_mode_status is aioaquarea.DeviceModeStatus.DEFROST,
+        detector=lambda device: device.parameters.device_mode_status is AquareaDeviceModeStatus.Defrost,
     ),
 ]
 
@@ -229,26 +217,31 @@ AQUAREA_DAILY_COUNTERS = [
 async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     aquarea_coordinators: list[AquareaDeviceCoordinator] = hass.data[DOMAIN][AQUAREA_COORDINATORS]
+    energy_coordinators: list[AquareaConsumptionCoordinator] = hass.data[DOMAIN].get(AQUAREA_ENERGY_COORDINATORS, [])
 
     for coordinator in aquarea_coordinators:
         entities.append(AquareaSensorEntity(coordinator, AQUAREA_OUTSIDE_TEMPERATURE_DESCRIPTION))
         entities.append(AquareaPumpDirectionSensor(coordinator))
         entities.append(AquareaPumpStatusSensor(coordinator))
-        if coordinator.device.has_tank:
+        if coordinator.device.parameters.has_tank:
             entities.append(AquareaSensorEntity(coordinator, AQUAREA_TANK_TEMPERATURE_DESCRIPTION))
         # Daily edge counters
         for desc in AQUAREA_DAILY_COUNTERS:
             entities.append(AquareaDailyCounterSensor(coordinator, desc))
-        # Accumulated energy sensors (month-to-date)
-        for desc in AQUAREA_ACCUMULATED_ENERGY_SENSORS:
-            if desc.exists_fn(coordinator):
-                entities.append(AquareaEnergyAccumulatedConsumptionSensor(coordinator, desc))
-        # Today's energy sensors (disabled by default)
-        for desc in AQUAREA_ENERGY_SENSORS:
-            if desc.exists_fn(coordinator):
-                entities.append(AquareaEnergyConsumptionSensor(coordinator, desc))
         # Connection status sensor
         entities.append(AquareaConnectionStatusSensor(coordinator))
+
+    aquarea_by_id = {coordinator.device_id: coordinator for coordinator in aquarea_coordinators}
+    for energy_coordinator in energy_coordinators:
+        device_coordinator = aquarea_by_id.get(energy_coordinator.device_id)
+        if device_coordinator is None:
+            continue
+        for desc in AQUAREA_ENERGY_SENSORS:
+            if desc.exists_fn(device_coordinator):
+                entities.append(AquareaEnergySensorEntity(energy_coordinator, desc))
+        for desc in AQUAREA_COST_SENSORS:
+            if desc.exists_fn(device_coordinator):
+                entities.append(AquareaEnergySensorEntity(energy_coordinator, desc))
 
     async_add_entities(entities)
 
@@ -288,12 +281,12 @@ class AquareaPumpDirectionSensor(AquareaDataEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = self.coordinator.device.current_direction.name
+        self._attr_native_value = self.coordinator.device.parameters.direction.name
         super()._handle_coordinator_update()
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the sensor."""
-        self._attr_native_value = self.coordinator.device.current_direction.name
+        self._attr_native_value = self.coordinator.device.parameters.direction.name
 
 
 class AquareaPumpStatusSensor(AquareaDataEntity, SensorEntity):
@@ -308,12 +301,12 @@ class AquareaPumpStatusSensor(AquareaDataEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = "On" if self.coordinator.device.pump_duty == 1 else "Off"
+        self._attr_native_value = "On" if self.coordinator.device.parameters.pump_duty == AquareaPumpDuty.On else "Off"
         super()._handle_coordinator_update()
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the sensor."""
-        self._attr_native_value = "On" if self.coordinator.device.pump_duty == 1 else "Off"
+        self._attr_native_value = "On" if self.coordinator.device.parameters.pump_duty == AquareaPumpDuty.On else "Off"
 
 
 class AquareaDailyCounterSensor(AquareaDataEntity, SensorEntity, RestoreEntity):
@@ -369,24 +362,25 @@ class AquareaDailyCounterSensor(AquareaDataEntity, SensorEntity, RestoreEntity):
         self._attr_native_value = self._count
 
 
-class AquareaEnergyAccumulatedConsumptionSensor(AquareaDataEntity, SensorEntity, RestoreEntity):
-    """Sensor for accumulated (month-to-date) energy consumption from the Aquarea device."""
+class AquareaEnergySensorEntity(AquareaEnergyEntity, SensorEntity, RestoreEntity):
+    """Sensor for today's energy consumption/cost from the Aquarea consumption endpoint."""
 
-    entity_description: AquareaEnergySensorEntityDescription
+    entity_description: AquareaEnergySensorEntityDescription  # type: ignore[reportIncompatibleVariableOverride]
 
     def __init__(
         self,
-        coordinator: AquareaDeviceCoordinator,
+        coordinator: AquareaConsumptionCoordinator,
         description: AquareaEnergySensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, description.key)
-        self.entity_description = description
-        self._attr_translation_key = description.key
+        self.entity_description = description  # type: ignore[reportIncompatibleVariableOverride]
         self._attr_device_class = description.device_class
         self._attr_state_class = description.state_class
         self._attr_native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_suggested_display_precision = description.suggested_display_precision
+        self._attr_entity_category = description.entity_category
+        self._attr_entity_registry_enabled_default = description.entity_registry_enabled_default
+        super().__init__(coordinator, description.key)
 
     async def async_added_to_hass(self) -> None:
         """Restore value from previous session."""
@@ -402,66 +396,12 @@ class AquareaEnergyAccumulatedConsumptionSensor(AquareaDataEntity, SensorEntity,
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the sensor."""
-        device = self.coordinator.device
-        now = dt_util.now()
-        try:
-            consumption = device.get_or_schedule_consumption(
-                now, self.entity_description.consumption_type
-            )
-            if consumption is not None:
-                self._attr_native_value = float(consumption)
-        except aioaquarea.DataNotAvailableError:
-            pass  # Keep last known value
-        except Exception:
-            pass  # Keep last known value
-
-
-class AquareaEnergyConsumptionSensor(AquareaDataEntity, SensorEntity, RestoreEntity):
-    """Sensor for today's energy consumption from the Aquarea device."""
-
-    entity_description: AquareaEnergySensorEntityDescription
-
-    def __init__(
-        self,
-        coordinator: AquareaDeviceCoordinator,
-        description: AquareaEnergySensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator, description.key)
-        self.entity_description = description
-        self._attr_translation_key = description.key
-        self._attr_device_class = description.device_class
-        self._attr_state_class = description.state_class
-        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
-        self._attr_suggested_display_precision = description.suggested_display_precision
-        self._attr_entity_registry_enabled_default = False
-
-    async def async_added_to_hass(self) -> None:
-        """Restore value from previous session."""
-        restored = await self.async_get_last_state()
-        if restored is not None and restored.state not in (None, "unknown", "unavailable"):
-            try:
-                self._attr_native_value = float(restored.state)
-            except ValueError:
-                self._attr_native_value = 0
-        else:
-            self._attr_native_value = 0
-        await super().async_added_to_hass()
-
-    def _async_update_attrs(self) -> None:
-        """Update the attributes of the sensor."""
-        device = self.coordinator.device
-        now = dt_util.now()
-        try:
-            consumption = device.get_or_schedule_consumption(
-                now, self.entity_description.consumption_type
-            )
-            if consumption is not None:
-                self._attr_native_value = float(consumption)
-        except aioaquarea.DataNotAvailableError:
-            pass  # Keep last known value
-        except Exception:
-            pass  # Keep last known value
+        consumption = self.coordinator.consumption
+        if consumption is None:
+            return
+        value = self.entity_description.get_state(consumption)
+        if value is not None:
+            self._attr_native_value = value
 
 
 class AquareaConnectionStatusSensor(AquareaDataEntity, SensorEntity):

--- a/custom_components/panasonic_cc/aquarea/switch.py
+++ b/custom_components/panasonic_cc/aquarea/switch.py
@@ -5,8 +5,6 @@ import asyncio
 import logging
 from typing import Any
 
-import aioaquarea
-
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.switch import (
@@ -14,6 +12,8 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
+
+from aio_panasonic_comfort_cloud.constants import AquareaForceDHW, AquareaForceHeater, AquareaHolidayTimer
 
 from ..const import DOMAIN
 from .base import AquareaDataEntity
@@ -46,10 +46,10 @@ class AquareaBaseSwitch(AquareaDataEntity, SwitchEntity):
         self._optimistic_is_on = None
         try:
             await self.coordinator.async_request_refresh()
-        except aioaquarea.RequestFailedError:
+        except Exception:
             _LOGGER.exception(
                 "Delayed refresh failed for device %s",
-                self.coordinator.device.device_id,
+                self.coordinator.device_id,
             )
 
 
@@ -67,20 +67,20 @@ class AquareaForceDHWSwitch(AquareaBaseSwitch):
         return "mdi:water-boiler" if self.is_on else "mdi:water-boiler-off"
 
     def _get_is_on(self) -> bool:
-        return self.coordinator.device.force_dhw is aioaquarea.ForceDHW.ON
+        return self.coordinator.device.parameters.force_dhw is AquareaForceDHW.On
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on Force DHW."""
         self._optimistic_is_on = True
         self.async_write_ha_state()
-        await self.coordinator.device.set_force_dhw(aioaquarea.ForceDHW.ON)
+        await self.coordinator.api_client.set_aquarea_force_dhw(self.coordinator.info, AquareaForceDHW.On)
         self.hass.async_create_task(self._schedule_refresh())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off Force DHW."""
         self._optimistic_is_on = False
         self.async_write_ha_state()
-        await self.coordinator.device.set_force_dhw(aioaquarea.ForceDHW.OFF)
+        await self.coordinator.api_client.set_aquarea_force_dhw(self.coordinator.info, AquareaForceDHW.Off)
         self.hass.async_create_task(self._schedule_refresh())
 
     def _async_update_attrs(self) -> None:
@@ -101,20 +101,20 @@ class AquareaForceHeaterSwitch(AquareaBaseSwitch):
         return "mdi:hvac" if self.is_on else "mdi:hvac-off"
 
     def _get_is_on(self) -> bool:
-        return self.coordinator.device.force_heater is aioaquarea.ForceHeater.ON
+        return self.coordinator.device.parameters.force_heater is AquareaForceHeater.On
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on Force Heater."""
         self._optimistic_is_on = True
         self.async_write_ha_state()
-        await self.coordinator.device.set_force_heater(aioaquarea.ForceHeater.ON)
+        await self.coordinator.api_client.set_aquarea_force_heater(self.coordinator.info, AquareaForceHeater.On)
         self.hass.async_create_task(self._schedule_refresh())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off Force Heater."""
         self._optimistic_is_on = False
         self.async_write_ha_state()
-        await self.coordinator.device.set_force_heater(aioaquarea.ForceHeater.OFF)
+        await self.coordinator.api_client.set_aquarea_force_heater(self.coordinator.info, AquareaForceHeater.Off)
         self.hass.async_create_task(self._schedule_refresh())
 
     def _async_update_attrs(self) -> None:
@@ -135,20 +135,20 @@ class AquareaHolidayTimerSwitch(AquareaBaseSwitch):
         return "mdi:timer-check" if self.is_on else "mdi:timer-off"
 
     def _get_is_on(self) -> bool:
-        return self.coordinator.device.holiday_timer is aioaquarea.HolidayTimer.ON
+        return self.coordinator.device.parameters.holiday_timer is AquareaHolidayTimer.On
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on Holiday Timer."""
         self._optimistic_is_on = True
         self.async_write_ha_state()
-        await self.coordinator.device.set_holiday_timer(aioaquarea.HolidayTimer.ON)
+        await self.coordinator.api_client.set_aquarea_holiday_timer(self.coordinator.info, AquareaHolidayTimer.On)
         self.hass.async_create_task(self._schedule_refresh())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off Holiday Timer."""
         self._optimistic_is_on = False
         self.async_write_ha_state()
-        await self.coordinator.device.set_holiday_timer(aioaquarea.HolidayTimer.OFF)
+        await self.coordinator.api_client.set_aquarea_holiday_timer(self.coordinator.info, AquareaHolidayTimer.Off)
         self.hass.async_create_task(self._schedule_refresh())
 
     def _async_update_attrs(self) -> None:
@@ -167,7 +167,7 @@ async def async_setup_entry(
     ]
 
     for coordinator in aquarea_coordinators:
-        if coordinator.device.has_tank:
+        if coordinator.device.parameters.has_tank:
             devices.append(AquareaForceDHWSwitch(coordinator))
         devices.append(AquareaForceHeaterSwitch(coordinator))
         devices.append(AquareaHolidayTimerSwitch(coordinator))

--- a/custom_components/panasonic_cc/aquarea/water_heater.py
+++ b/custom_components/panasonic_cc/aquarea/water_heater.py
@@ -14,7 +14,7 @@ from homeassistant.const import UnitOfTemperature, PRECISION_WHOLE, ATTR_TEMPERA
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 
-from aioaquarea.data import DeviceAction, OperationStatus
+from aio_panasonic_comfort_cloud.constants import AquareaOperationStatus
 
 from ..const import DOMAIN
 from .base import AquareaDataEntity
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entities = []
     aquarea_coordinators: list[AquareaDeviceCoordinator] = hass.data[DOMAIN][AQUAREA_COORDINATORS]
     for aquarea_coordinator in aquarea_coordinators:
-        if aquarea_coordinator.device.tank is None:
+        if not aquarea_coordinator.device.parameters.has_tank:
             continue
         entities.append(AquareaWaterHeater(aquarea_coordinator, AQUAREA_WATER_TANK_DESCRIPTION))
     async_add_entities(entities)
@@ -69,18 +69,20 @@ class AquareaWaterHeater(AquareaDataEntity, WaterHeaterEntity):
 
     def _async_update_attrs(self) -> None:
         """Update attributes."""
-        device = self.coordinator.device
+        tank = self.coordinator.device.parameters.tank
 
-        if device.tank is None:
+        if tank is None:
             self._attr_available = False
             return
 
-        self._attr_min_temp = device.tank.heat_min
-        self._attr_max_temp = device.tank.heat_max
-        self._attr_target_temperature = device.tank.target_temperature
-        self._attr_current_temperature = device.tank.temperature
+        if tank.heat_min is not None:
+            self._attr_min_temp = tank.heat_min
+        if tank.heat_max is not None:
+            self._attr_max_temp = tank.heat_max
+        self._attr_target_temperature = tank.heat_set
+        self._attr_current_temperature = tank.temperature
 
-        if device.tank.operation_status == OperationStatus.OFF:
+        if tank.operation_status == AquareaOperationStatus.Off:
             self._attr_current_operation = STATE_OFF
         else:
             self._attr_current_operation = STATE_HEAT_PUMP
@@ -90,15 +92,21 @@ class AquareaWaterHeater(AquareaDataEntity, WaterHeaterEntity):
         temperature: float | None = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
-        if self.coordinator.device.tank is None:
+        if self.coordinator.device.parameters.tank is None:
             return
-        await self.coordinator.device.tank.set_target_temperature(int(temperature))
+        await self.coordinator.api_client.set_aquarea_tank_temperature(
+            self.coordinator.info, int(temperature)
+        )
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set operation mode."""
-        if self.coordinator.device.tank is None:
+        if self.coordinator.device.parameters.tank is None:
             return
         if operation_mode == STATE_HEAT_PUMP:
-            await self.coordinator.device.tank.turn_on()
+            await self.coordinator.api_client.set_aquarea_tank_operation_status(
+                self.coordinator.info, AquareaOperationStatus.On
+            )
         elif operation_mode == STATE_OFF:
-            await self.coordinator.device.tank.turn_off()
+            await self.coordinator.api_client.set_aquarea_tank_operation_status(
+                self.coordinator.info, AquareaOperationStatus.Off
+            )

--- a/custom_components/panasonic_cc/const.py
+++ b/custom_components/panasonic_cc/const.py
@@ -11,6 +11,8 @@ MANUFACTURER = "Panasonic"
 DATA_COORDINATORS = "data_coordinators"
 ENERGY_COORDINATORS = "energy_coordinators"
 AQUAREA_COORDINATORS = "aquarea_coordinators"
+AQUAREA_ENERGY_COORDINATORS = "aquarea_energy_coordinators"
+HWS_COORDINATORS = "hws_coordinators"
 
 NOTIFICATION_AUTH_EXPIRED = f"{DOMAIN}_auth_expired"
 

--- a/custom_components/panasonic_cc/diagnostics.py
+++ b/custom_components/panasonic_cc/diagnostics.py
@@ -13,6 +13,7 @@ from .const import (
     DATA_COORDINATORS,
     DOMAIN,
     ENERGY_COORDINATORS,
+    HWS_COORDINATORS,
 )
 
 TO_REDACT = {
@@ -74,14 +75,30 @@ async def async_get_config_entry_diagnostics(
     aquarea_devices = []
     for coordinator in aquarea_coordinators:
         if coordinator._device is not None:
-            aquarea_device = coordinator._device
+            aquarea_params = coordinator._device.parameters
             aquarea_devices.append(
                 {
                     "id": coordinator.device_id,
-                    "name": aquarea_device.device_name,
-                    "model": aquarea_device.model or "",
-                    "firmware_version": aquarea_device.firmware_version,
-                    "manufacturer": aquarea_device.manufacturer,
+                    "name": coordinator._device_info.name,
+                    "model": coordinator._device_info.model,
+                    "operation_mode": aquarea_params.operation_mode.name if aquarea_params.operation_mode else None,
+                    "has_tank": aquarea_params.has_tank,
+                    "zone_count": len(aquarea_params.zones),
+                }
+            )
+
+    hws_coordinators = hass.data[DOMAIN].get(HWS_COORDINATORS, [])
+    hws_devices = []
+    for coordinator in hws_coordinators:
+        if coordinator._device is not None:
+            hws_params = coordinator._device.parameters
+            hws_devices.append(
+                {
+                    "id": coordinator.device_id,
+                    "name": coordinator._device_info.name,
+                    "model": coordinator._device_info.model,
+                    "hpu_operation_status": hws_params.hpu_operation_status.name,
+                    "tank_temperature": hws_params.tank_temperature,
                 }
             )
 
@@ -91,6 +108,7 @@ async def async_get_config_entry_diagnostics(
             "devices": devices,
             "energy_data": energy_data,
             "aquarea_devices": aquarea_devices,
+            "hws_devices": hws_devices,
         },
         TO_REDACT,
     )

--- a/custom_components/panasonic_cc/hws/__init__.py
+++ b/custom_components/panasonic_cc/hws/__init__.py
@@ -1,0 +1,110 @@
+"""HWS (standalone Heat Pump Hot Water tank) device setup and coordination."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aio_panasonic_comfort_cloud import ApiClient, PanasonicDeviceInfo
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from ..const import DOMAIN, MANUFACTURER
+from .const import HWS_COORDINATORS
+from .coordinator import HwsDeviceCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Platforms that the HWS slice provides
+PLATFORMS = [
+    "sensor",
+    "switch",
+    "water_heater",
+]
+
+
+async def async_setup_hws(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    panasonic_api: ApiClient,
+) -> list[HwsDeviceCoordinator]:
+    """Set up HWS devices: build coordinators from the shared ApiClient session and register devices."""
+    hws_devices = panasonic_api.hws_devices
+    if not hws_devices:
+        hass.data[DOMAIN][HWS_COORDINATORS] = []
+        return []
+
+    config = {**entry.data, **entry.options}
+
+    hws_coordinators: list[HwsDeviceCoordinator] = []
+    hws_coordinators_uninitialized: list[tuple[HwsDeviceCoordinator, PanasonicDeviceInfo]] = []
+
+    for device_info in hws_devices:
+        try:
+            hws_coordinator = HwsDeviceCoordinator(hass, config, panasonic_api, device_info)
+            hws_coordinators_uninitialized.append((hws_coordinator, device_info))
+        except Exception as exc:
+            _LOGGER.warning(
+                "Failed to create coordinator for HWS device %s: %s",
+                device_info.name,
+                exc,
+                exc_info=True,
+            )
+
+    # Refresh all HWS coordinators in parallel
+    async def _init_hws(coordinator: HwsDeviceCoordinator, device_info: PanasonicDeviceInfo) -> None:
+        try:
+            await coordinator.async_config_entry_first_refresh()
+            hws_coordinators.append(coordinator)
+        except Exception as exc:
+            _LOGGER.warning(
+                "Failed to setup HWS device %s: %s",
+                device_info.name,
+                exc,
+                exc_info=True,
+            )
+
+    await asyncio.gather(
+        *(_init_hws(coordinator, device_info) for coordinator, device_info in hws_coordinators_uninitialized),
+        return_exceptions=True,
+    )
+
+    hass.data[DOMAIN][HWS_COORDINATORS] = hws_coordinators
+
+    # Register devices in device registry
+    device_registry = dr.async_get(hass)
+    for coordinator in hws_coordinators:
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, coordinator.device_id)},
+            name=coordinator._device_info.name,
+            manufacturer=MANUFACTURER,
+            model=coordinator._device_info.model,
+            sw_version=coordinator.api_client.app_version,
+        )
+
+    return hws_coordinators
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    panasonic_api: ApiClient,
+) -> bool:
+    """Set up HWS from a config entry."""
+    hws_coordinators = await async_setup_hws(hass, entry, panasonic_api)
+
+    if not hws_coordinators:
+        return True  # Not an error, just no HWS devices
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/panasonic_cc/hws/base.py
+++ b/custom_components/panasonic_cc/hws/base.py
@@ -1,0 +1,35 @@
+"""Base classes for HWS entities."""
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import HwsDeviceCoordinator
+
+
+class HwsDataEntity(CoordinatorEntity[HwsDeviceCoordinator]):
+    """Base class for HWS data entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: HwsDeviceCoordinator, key: str) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_translation_key = key
+        self._attr_unique_id = f"{coordinator.device_id}-{key}"
+        self._attr_device_info = self.coordinator.device_info
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is added to hass."""
+        await super().async_added_to_hass()
+        self._async_update_attrs()
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        self.async_write_ha_state()
+
+    @abstractmethod
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the entity."""

--- a/custom_components/panasonic_cc/hws/const.py
+++ b/custom_components/panasonic_cc/hws/const.py
@@ -1,0 +1,6 @@
+"""Constants for HWS (standalone Heat Pump Hot Water tank) devices."""
+
+HWS_COORDINATORS = "hws_coordinators"
+
+HWS_SWITCH_DELAY = 10.0
+HWS_WATER_HEATER_DELAY = 10.0

--- a/custom_components/panasonic_cc/hws/coordinator.py
+++ b/custom_components/panasonic_cc/hws/coordinator.py
@@ -1,0 +1,229 @@
+"""Coordinators for HWS (standalone Heat Pump Hot Water tank) devices."""
+import asyncio
+import logging
+from datetime import timedelta
+
+from aiohttp import ClientResponseError
+from homeassistant.components.persistent_notification import async_create
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.entity import DeviceInfo
+
+from aio_panasonic_comfort_cloud import ApiClient, HwsDevice, PanasonicDeviceInfo
+
+from ..const import (
+    DEFAULT_DEVICE_FETCH_INTERVAL,
+    CONF_DEVICE_FETCH_INTERVAL,
+    DOMAIN,
+    MANUFACTURER,
+    NOTIFICATION_AUTH_EXPIRED,
+)
+from ..error_handler import classify_error, FriendlyError, ErrorCategory
+
+MAX_CONSECUTIVE_FAILURES = 5
+BACKOFF_MULTIPLIER = 2
+MAX_UPDATE_INTERVAL = 600  # seconds
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _is_auth_error(err: Exception) -> bool:
+    """Check if an exception is caused by authentication failure."""
+    if isinstance(err, ClientResponseError) and err.status == 401:
+        return True
+    error_str = str(err).lower()
+    return any(kw in error_str for kw in ["401", "unauthorized", "authentication", "token", "expired", "invalid session"])
+
+
+def _create_auth_expired_notification(hass: HomeAssistant) -> None:
+    """Create a persistent notification for expired authentication."""
+    async_create(
+        hass,
+        message="Panasonic Comfort Cloud authentication has expired. Please re-authenticate by removing and re-adding the integration.",
+        title="Panasonic Comfort Cloud - Authentication Expired",
+        notification_id=NOTIFICATION_AUTH_EXPIRED,
+    )
+
+
+class HwsDeviceCoordinator(DataUpdateCoordinator[int]):
+    """HWS device data coordinator."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config: dict,
+        api_client: ApiClient,
+        device_info: PanasonicDeviceInfo,
+    ) -> None:
+        """Initialize the coordinator."""
+        self._base_interval = config.get(
+            CONF_DEVICE_FETCH_INTERVAL, DEFAULT_DEVICE_FETCH_INTERVAL
+        )
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"HWS Device Coordinator ({device_info.name})",
+            update_interval=timedelta(seconds=self._base_interval),
+        )
+        self._api_client = api_client
+        self._device_info = device_info
+        self._device: HwsDevice | None = None
+        self._update_id = 0
+        self._refresh_task: asyncio.Task | None = None
+        self._consecutive_failures = 0
+        self._auth_failed = False
+        self._last_device_state_hash: int | None = None
+        self._last_error: FriendlyError | None = None
+
+    @property
+    def last_error(self) -> FriendlyError | None:
+        """Return the last error that occurred."""
+        return self._last_error
+
+    @property
+    def connection_status(self) -> str:
+        """Return the current connection status."""
+        if self._auth_failed:
+            return "authentication_error"
+        if self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            return "disconnected"
+        if self._consecutive_failures > 0:
+            return "degraded"
+        return "connected"
+
+    @property
+    def device(self) -> HwsDevice:
+        """Return the current device state."""
+        if self._device is None:
+            raise ValueError("Device has not been initialized")
+        return self._device
+
+    @property
+    def api_client(self) -> ApiClient:
+        """Return the API client."""
+        return self._api_client
+
+    @property
+    def info(self) -> PanasonicDeviceInfo:
+        """Return the raw device info used for ApiClient.set_hws_* calls."""
+        return self._device_info
+
+    @property
+    def device_id(self) -> str:
+        """Return the device ID."""
+        return self._device_info.id
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_info.id)},
+            manufacturer=MANUFACTURER,
+            model=self._device_info.model,
+            name=self._device_info.name,
+            sw_version=self._api_client.app_version,
+        )
+
+    def _device_state_hash(self) -> int:
+        """Compute a hash of the device state for change detection."""
+        if self._device is None:
+            return 0
+        params = self._device.parameters
+        return hash((
+            params.hpu_operation_status,
+            params.operation_mode,
+            params.boost_mode,
+            params.tank_temperature,
+        ))
+
+    async def _async_update_data(self) -> int:
+        """Fetch data from API."""
+        if self._auth_failed:
+            raise UpdateFailed("Authentication failed — coordinator disabled")
+
+        try:
+            if self._device is None:
+                self._device = self._api_client.get_hws_device(self._device_info)
+                self._update_id = 1
+                self._last_device_state_hash = self._device_state_hash()
+                self._reset_backoff()
+                return self._update_id
+            if await self._api_client.try_update_hws_device(self._device):
+                current_hash = self._device_state_hash()
+                if current_hash != self._last_device_state_hash:
+                    self._last_device_state_hash = current_hash
+                    self._update_id += 1
+                    self._reset_backoff()
+                    return self._update_id
+            self._reset_backoff()
+        except Exception as err:
+            if _is_auth_error(err):
+                self._auth_failed = True
+                _LOGGER.error(
+                    "%s Authentication has expired or is invalid. Please re-authenticate by removing and re-adding the integration.",
+                    self._device_info.name,
+                    exc_info=True,
+                )
+                _create_auth_expired_notification(self.hass)
+                raise UpdateFailed("Authentication failed — coordinator disabled") from err
+            self._handle_failure(err)
+            friendly = classify_error(err)
+            raise UpdateFailed(f"{friendly.title}: {friendly.message}") from err
+        return self._update_id
+
+    def _reset_backoff(self) -> None:
+        """Reset circuit breaker and restore base polling interval."""
+        if self._consecutive_failures > 0:
+            _LOGGER.debug(
+                "%s API recovered after %d consecutive failure(s)",
+                self._device_info.name,
+                self._consecutive_failures,
+            )
+        self._consecutive_failures = 0
+        self._last_error = None
+        self.update_interval = timedelta(seconds=self._base_interval)
+
+    def _handle_failure(self, err: Exception | None = None) -> None:
+        """Handle API failure with exponential backoff."""
+        self._consecutive_failures += 1
+        new_interval = min(
+            self._base_interval * (BACKOFF_MULTIPLIER ** self._consecutive_failures),
+            MAX_UPDATE_INTERVAL,
+        )
+        self.update_interval = timedelta(seconds=new_interval)
+        if err is not None:
+            self._last_error = classify_error(err)
+            _LOGGER.warning(
+                "%s API failure %d/%d — %s: %s — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                self._last_error.title,
+                self._last_error.message,
+                new_interval,
+            )
+        else:
+            _LOGGER.warning(
+                "%s API failure %d/%d — polling interval increased to %ds",
+                self._device_info.name,
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                new_interval,
+            )
+
+    async def async_schedule_refresh(self) -> None:
+        """Schedule a debounced refresh of device data."""
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            self._refresh_task = None
+
+        async def _delayed_refresh() -> None:
+            try:
+                await asyncio.sleep(2)
+                await self.async_request_refresh()
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._refresh_task = None
+
+        self._refresh_task = self.hass.async_create_task(_delayed_refresh())

--- a/custom_components/panasonic_cc/hws/sensor.py
+++ b/custom_components/panasonic_cc/hws/sensor.py
@@ -1,0 +1,134 @@
+"""HWS (standalone Heat Pump Hot Water tank) sensor entities."""
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from aio_panasonic_comfort_cloud import HwsDevice
+from aio_panasonic_comfort_cloud.constants import AquareaOperationStatus
+
+from homeassistant.const import UnitOfTemperature, EntityCategory
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass,
+    SensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+from ..const import DOMAIN
+from .base import HwsDataEntity
+from .coordinator import HwsDeviceCoordinator
+from .const import HWS_COORDINATORS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HwsSensorEntityDescription(SensorEntityDescription):
+    """Describes HWS sensor entity."""
+    get_state: Callable[[HwsDevice], Any]
+
+
+HWS_TANK_TEMPERATURE_DESCRIPTION = HwsSensorEntityDescription(
+    key="tank_temperature",
+    translation_key="tank_temperature",
+    name="Tank Temperature",
+    icon="mdi:thermometer",
+    device_class=SensorDeviceClass.TEMPERATURE,
+    state_class=SensorStateClass.MEASUREMENT,
+    native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    get_state=lambda device: device.parameters.tank_temperature,
+)
+
+HWS_HPU_STATUS_DESCRIPTION = HwsSensorEntityDescription(
+    key="hpu_operation_status",
+    translation_key="hpu_operation_status",
+    name="Heat Pump Status",
+    icon="mdi:heat-pump",
+    device_class=SensorDeviceClass.ENUM,
+    options=[status.name for status in AquareaOperationStatus],
+    entity_category=EntityCategory.DIAGNOSTIC,
+    get_state=lambda device: device.parameters.hpu_operation_status.name,
+)
+
+# The meaning of operation_mode hasn't been confirmed against a real device
+# (see aio_panasonic_comfort_cloud/models/hws.py) — exposed as a raw
+# diagnostic value, disabled by default, so testers can report back what
+# they observe.
+HWS_OPERATION_MODE_DESCRIPTION = HwsSensorEntityDescription(
+    key="operation_mode",
+    translation_key="operation_mode",
+    name="Operation Mode (raw)",
+    icon="mdi:cog",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    entity_registry_enabled_default=False,
+    get_state=lambda device: device.parameters.operation_mode,
+)
+
+# Connection status sensor options
+HWS_CONNECTION_STATUS_OPTIONS = ["connected", "degraded", "disconnected", "authentication_error"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    """Set up the HWS sensors."""
+    entities = []
+    hws_coordinators: list[HwsDeviceCoordinator] = hass.data[DOMAIN][HWS_COORDINATORS]
+
+    for coordinator in hws_coordinators:
+        entities.append(HwsSensorEntity(coordinator, HWS_TANK_TEMPERATURE_DESCRIPTION))
+        entities.append(HwsSensorEntity(coordinator, HWS_HPU_STATUS_DESCRIPTION))
+        entities.append(HwsSensorEntity(coordinator, HWS_OPERATION_MODE_DESCRIPTION))
+        entities.append(HwsConnectionStatusSensor(coordinator))
+
+    async_add_entities(entities)
+
+
+class HwsSensorEntity(HwsDataEntity, SensorEntity):
+    """Representation of an HWS sensor."""
+
+    entity_description: HwsSensorEntityDescription  # type: ignore[reportIncompatibleVariableOverride]
+
+    def __init__(self, coordinator: HwsDeviceCoordinator, description: HwsSensorEntityDescription):
+        """Initialize the sensor."""
+        self.entity_description = description  # type: ignore[reportIncompatibleVariableOverride]
+        super().__init__(coordinator, description.key)
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        self._attr_native_value = self.entity_description.get_state(self.coordinator.device)
+
+
+class HwsConnectionStatusSensor(HwsDataEntity, SensorEntity):
+    """Sensor that reports the connection status and error information for an HWS device."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "connection_status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = HWS_CONNECTION_STATUS_OPTIONS
+    _attr_icon = "mdi:network"
+
+    def __init__(self, coordinator: HwsDeviceCoordinator) -> None:
+        """Initialize the connection status sensor."""
+        super().__init__(coordinator, "connection_status")
+        self._attr_unique_id = f"{coordinator.device_id}-connection_status"
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        self._attr_native_value = self.coordinator.connection_status
+
+        attrs = {}
+        attrs["consecutive_failures"] = self.coordinator._consecutive_failures
+
+        if self.coordinator.last_error is not None:
+            err = self.coordinator.last_error
+            attrs["last_error_title"] = err.title
+            attrs["last_error_message"] = err.message
+            attrs["last_error_category"] = err.category.name.lower()
+            attrs["last_error_recoverable"] = err.is_recoverable
+            if err.suggestion:
+                attrs["last_error_suggestion"] = err.suggestion
+
+        self._attr_extra_state_attributes = attrs

--- a/custom_components/panasonic_cc/hws/switch.py
+++ b/custom_components/panasonic_cc/hws/switch.py
@@ -1,0 +1,95 @@
+"""HWS (standalone Heat Pump Hot Water tank) switch entities."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+)
+
+from aio_panasonic_comfort_cloud.constants import AquareaOperationStatus
+
+from ..const import DOMAIN
+from .base import HwsDataEntity
+from .coordinator import HwsDeviceCoordinator
+from .const import HWS_COORDINATORS, HWS_SWITCH_DELAY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HwsBoostModeSwitch(HwsDataEntity, SwitchEntity):
+    """Switch to enable/disable boost mode on HWS devices.
+
+    Uses the library's ``set_hws_boost_mode`` setter, which its own
+    docstrings call "unverified/best-effort" — the write endpoint is
+    confirmed only from an app capture, not tested against a real device.
+    """
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _optimistic_is_on: bool | None = None
+
+    def __init__(self, coordinator: HwsDeviceCoordinator) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, "boost_mode")
+        self._attr_translation_key = "boost_mode"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return "mdi:water-boiler" if self.is_on else "mdi:water-boiler-off"
+
+    @property
+    def is_on(self) -> bool:
+        """Return the switch state."""
+        if self._optimistic_is_on is not None:
+            return self._optimistic_is_on
+        return self.coordinator.device.parameters.boost_mode is AquareaOperationStatus.On
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on boost mode."""
+        self._optimistic_is_on = True
+        self.async_write_ha_state()
+        await self.coordinator.api_client.set_hws_boost_mode(self.coordinator.info, AquareaOperationStatus.On)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off boost mode."""
+        self._optimistic_is_on = False
+        self.async_write_ha_state()
+        await self.coordinator.api_client.set_hws_boost_mode(self.coordinator.info, AquareaOperationStatus.Off)
+        self.hass.async_create_task(self._schedule_refresh())
+
+    async def _schedule_refresh(self, delay: float = HWS_SWITCH_DELAY) -> None:
+        """Schedule a coordinator refresh after a short delay."""
+        await asyncio.sleep(delay)
+        self._optimistic_is_on = None
+        try:
+            await self.coordinator.async_request_refresh()
+        except Exception:
+            _LOGGER.exception(
+                "Delayed refresh failed for device %s",
+                self.coordinator.device_id,
+            )
+
+    def _async_update_attrs(self) -> None:
+        """No-op — state is read via is_on property."""
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Any,
+) -> None:
+    """Set up the HWS switches."""
+    entities = []
+    hws_coordinators: list[HwsDeviceCoordinator] = hass.data[DOMAIN][HWS_COORDINATORS]
+
+    for coordinator in hws_coordinators:
+        entities.append(HwsBoostModeSwitch(coordinator))
+
+    async_add_entities(entities)

--- a/custom_components/panasonic_cc/hws/water_heater.py
+++ b/custom_components/panasonic_cc/hws/water_heater.py
@@ -1,0 +1,102 @@
+"""HWS (standalone Heat Pump Hot Water tank) water heater entities."""
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityDescription,
+    WaterHeaterEntityFeature,
+    STATE_HEAT_PUMP,
+    STATE_OFF,
+)
+from homeassistant.const import UnitOfTemperature, PRECISION_WHOLE, ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+from aio_panasonic_comfort_cloud.constants import AquareaOperationStatus
+
+from ..const import DOMAIN
+from .base import HwsDataEntity
+from .coordinator import HwsDeviceCoordinator
+from .const import HWS_COORDINATORS
+
+_LOGGER = logging.getLogger(__name__)
+
+# The API reports no min/max bounds for the tank temperature — assumed from
+# the same range used for Aquarea's tank (aquarea/water_heater.py), not
+# provided by the API.
+DEFAULT_MIN_TEMP = 40
+DEFAULT_MAX_TEMP = 65
+
+
+@dataclass(frozen=True, kw_only=True)
+class HwsWaterHeaterEntityDescription(WaterHeaterEntityDescription):
+    """Describes an HWS Water Heater entity."""
+
+
+HWS_WATER_TANK_DESCRIPTION = HwsWaterHeaterEntityDescription(
+    key="tank",
+    translation_key="tank",
+    name="Tank",
+)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    """Set up the HWS water heater."""
+    entities = []
+    hws_coordinators: list[HwsDeviceCoordinator] = hass.data[DOMAIN][HWS_COORDINATORS]
+    for coordinator in hws_coordinators:
+        entities.append(HwsWaterHeater(coordinator, HWS_WATER_TANK_DESCRIPTION))
+    async_add_entities(entities)
+
+
+class HwsWaterHeater(HwsDataEntity, WaterHeaterEntity):
+    """Representation of an HWS hot water tank.
+
+    ``tank_temperature`` is the only value the API reports, and it's also
+    the field ``set_hws_tank_temperature`` writes — there's no separate
+    sensed-vs-setpoint distinction in the payload (unlike Aquarea's tank),
+    so it's treated purely as the target temperature here.
+    """
+
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = WaterHeaterEntityFeature.TARGET_TEMPERATURE | WaterHeaterEntityFeature.OPERATION_MODE
+    _attr_operation_list = [STATE_HEAT_PUMP, STATE_OFF]
+    _attr_precision = PRECISION_WHOLE
+    _attr_target_temperature_step = 1
+    _attr_min_temp = DEFAULT_MIN_TEMP
+    _attr_max_temp = DEFAULT_MAX_TEMP
+
+    def __init__(
+        self,
+        coordinator: HwsDeviceCoordinator,
+        description: HwsWaterHeaterEntityDescription,
+    ) -> None:
+        """Initialize the water heater entity."""
+        self.entity_description = description
+        super().__init__(coordinator, description.key)
+
+    def _async_update_attrs(self) -> None:
+        """Update attributes."""
+        params = self.coordinator.device.parameters
+        self._attr_target_temperature = params.tank_temperature
+
+        if params.hpu_operation_status == AquareaOperationStatus.Off:
+            self._attr_current_operation = STATE_OFF
+        else:
+            self._attr_current_operation = STATE_HEAT_PUMP
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        temperature: float | None = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        await self.coordinator.api_client.set_hws_tank_temperature(self.coordinator.info, float(temperature))
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set operation mode."""
+        if operation_mode == STATE_HEAT_PUMP:
+            await self.coordinator.api_client.set_hws_operation_status(self.coordinator.info, AquareaOperationStatus.On)
+        elif operation_mode == STATE_OFF:
+            await self.coordinator.api_client.set_hws_operation_status(self.coordinator.info, AquareaOperationStatus.Off)

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -13,9 +13,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sockless-coding/panasonic_cc/issues",
   "requirements": [
-    "aio-panasonic-comfort-cloud==2026.6.2",
-    "aioaquarea==1.0.7"
+    "aio-panasonic-comfort-cloud==2026.8.2"
   ],
   "quality_scale": "silver",
-  "version": "2026.6.7"
+  "version": "2026.8.0"
 }

--- a/custom_components/panasonic_cc/sensor.py
+++ b/custom_components/panasonic_cc/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .panasonic.sensor import async_setup_entry as panasonic_setup
 from .aquarea.sensor import async_setup_entry as aquarea_setup
+from .hws.sensor import async_setup_entry as hws_setup
 
 
 async def async_setup_entry(
@@ -15,6 +16,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: Any,
 ) -> None:
-    """Set up the sensor entities for both Panasonic and Aquarea."""
+    """Set up the sensor entities for Panasonic, Aquarea and HWS."""
     await panasonic_setup(hass, entry, async_add_entities)
     await aquarea_setup(hass, entry, async_add_entities)
+    await hws_setup(hass, entry, async_add_entities)

--- a/custom_components/panasonic_cc/switch.py
+++ b/custom_components/panasonic_cc/switch.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .panasonic.switch import async_setup_entry as panasonic_setup
 from .aquarea.switch import async_setup_entry as aquarea_setup
+from .hws.switch import async_setup_entry as hws_setup
 
 
 async def async_setup_entry(
@@ -15,6 +16,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: Any,
 ) -> None:
-    """Set up the switch entities for both Panasonic and Aquarea."""
+    """Set up the switch entities for Panasonic, Aquarea and HWS."""
     await panasonic_setup(hass, entry, async_add_entities)
     await aquarea_setup(hass, entry, async_add_entities)
+    await hws_setup(hass, entry, async_add_entities)

--- a/custom_components/panasonic_cc/water_heater.py
+++ b/custom_components/panasonic_cc/water_heater.py
@@ -1,4 +1,4 @@
-"""Water heater entities for Aquarea devices."""
+"""Water heater entities for Aquarea and HWS devices."""
 from __future__ import annotations
 
 from typing import Any
@@ -7,6 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .aquarea.water_heater import async_setup_entry as aquarea_setup
+from .hws.water_heater import async_setup_entry as hws_setup
 
 
 async def async_setup_entry(
@@ -14,5 +15,6 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: Any,
 ) -> None:
-    """Set up the water heater entities for Aquarea devices."""
+    """Set up the water heater entities for Aquarea and HWS devices."""
     await aquarea_setup(hass, entry, async_add_entities)
+    await hws_setup(hass, entry, async_add_entities)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Panasonic Comfort Cloud",
-    "homeassistant": "2024.12.1",
+    "homeassistant": "2025.12.1",
     "render_readme": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 aiohttp
-aio-panasonic-comfort-cloud==2026.6.1
-aioaquarea==1.0.7
+aio-panasonic-comfort-cloud==2026.8.2


### PR DESCRIPTION

- Add new HWS (Hot Water System) integration for standalone heat pump hot water tanks (e.g., HE-UM40CR), including water heater, sensors, switch (boost mode), and coordinator.

- Migrate Aquarea from separate aioaquarea client to the unified aio_panasonic_comfort_cloud ApiClient, eliminating duplicate auth flows and consolidating all device types under a single session.

- Add daily energy consumption sensors for Aquarea: "Consumption Today" (heating/cooling/tank) and optional "Cost Today", backed by a new AquareaConsumptionCoordinator with configurable fetch interval.

- Add DHW/Zone/Defrost cycle counter sensors for Aquarea (diagnostic).

- Update device info to use raw deviceGuid for backward-compatible entity IDs across the migration from aioaquarea.

- Remove aioaquarea dependency; all Aquarea and HWS support now provided by aio_panasonic_comfort_cloud.

- Update README with HWS feature documentation and revised sensor list.