### PR TITLE
fix(config_flow): rename reconfigure step from reconfigure_confirm to reconfigure

### DIFF
--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -102,7 +102,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a reconfiguration flow."""
         if user_input is None:
             return self.async_show_form(
-                step_id="reconfigure_confirm",
+                step_id="reconfigure",
                 data_schema=vol.Schema({
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,

--- a/custom_components/panasonic_cc/strings.json
+++ b/custom_components/panasonic_cc/strings.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Energy fetch interval (seconds)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure Panasonic Comfort Cloud",
         "description": "Enter your Panasonic ID and password to re-authenticate",
         "data": {

--- a/custom_components/panasonic_cc/translations/cs.json
+++ b/custom_components/panasonic_cc/translations/cs.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Prodleva vyčítání energie (sekunda)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Překonfigurace Panasonic Comfort Cloud",
         "description": "Zadejte vaše Panasonic ID a heslo pro opětovné ověření",
         "data": {

--- a/custom_components/panasonic_cc/translations/de.json
+++ b/custom_components/panasonic_cc/translations/de.json
@@ -14,7 +14,7 @@
             "energy_fetch_interval": "Energieabrufintervall (Sekunden)"
           }
         },
-        "reconfigure_confirm": {
+        "reconfigure": {
           "title": "Panasonic Comfort Cloud neu konfigurieren",
           "description": "Geben Sie Ihre Panasonic-ID und Ihr Passwort ein, um sich neu zu authentifizieren",
           "data": {

--- a/custom_components/panasonic_cc/translations/en.json
+++ b/custom_components/panasonic_cc/translations/en.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Energy fetch interval (seconds)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure Panasonic Comfort Cloud",
         "description": "Enter your Panasonic ID and password to re-authenticate",
         "data": {

--- a/custom_components/panasonic_cc/translations/es.json
+++ b/custom_components/panasonic_cc/translations/es.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Intervalo de obtención de energía (segundos)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Panasonic Comfort Cloud",
         "description": "Introduce tu ID de Panasonic y tu contraseña para volver a autenticarte",
         "data": {

--- a/custom_components/panasonic_cc/translations/fr.json
+++ b/custom_components/panasonic_cc/translations/fr.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Intervalle de récupération de l'énergie (secondes)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurer Panasonic Comfort Cloud",
         "description": "Entrez votre identifiant Panasonic et votre mot de passe pour vous réauthentifier",
         "data": {

--- a/custom_components/panasonic_cc/translations/it.json
+++ b/custom_components/panasonic_cc/translations/it.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Intervallo interrogazione energia (secondi)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Riconfigura Panasonic Comfort Cloud",
         "description": "Inserisci il tuo ID Panasonic e password per riconnettersi",
         "data": {

--- a/custom_components/panasonic_cc/translations/nb.json
+++ b/custom_components/panasonic_cc/translations/nb.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Energieopphentingsintervall (sekunder)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Konfigurer Panasonic Comfort Cloud på nytt",
         "description": "Skriv inn Panasonic ID og passord for å autentisere på nytt",
         "data": {

--- a/custom_components/panasonic_cc/translations/nl.json
+++ b/custom_components/panasonic_cc/translations/nl.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Energieophalinginterval (seconden)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Panasonic Comfort Cloud opnieuw configureren",
         "description": "Voer uw Panasonic ID en wachtwoord in om opnieuw te authenticeren",
         "data": {

--- a/custom_components/panasonic_cc/translations/pl.json
+++ b/custom_components/panasonic_cc/translations/pl.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Interwał pobierania energii (sekundy)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Ponowna konfiguracja Panasonic Comfort Cloud",
         "description": "Wprowadź swoje Panasonic ID i hasło, aby ponownie uwierzytelnić",
         "data": {

--- a/custom_components/panasonic_cc/translations/pt.json
+++ b/custom_components/panasonic_cc/translations/pt.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Intervalo de obtenção de energia (segundos)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Panasonic Comfort Cloud",
         "description": "Introduza o seu ID da Panasonic e a sua palavra-passe para reautenticar",
         "data": {

--- a/custom_components/panasonic_cc/translations/sv.json
+++ b/custom_components/panasonic_cc/translations/sv.json
@@ -14,7 +14,7 @@
           "energy_fetch_interval": "Energihämtningsintervall (sekunder)"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Konfigurera Panasonic Comfort Cloud på nytt",
         "description": "Fyll i ditt Panasonic ID och lösenord för att autentisera på nytt",
         "data": {


### PR DESCRIPTION
The Home Assistant reconfigure flow expects the step_id to match the step key in strings/translations. Renaming `reconfigure_confirm` to `reconfigure` across config_flow.py, strings.json, and all translation files to ensure proper localization and flow handling.