### PR TITLE
feat: add 2FA/MFA support to config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ data:
 ## Troubleshooting
 
 ### Authentication Issues
-- **"Missing required parameter: code"** — You must use SMS-based 2FA. Other 2FA methods are not supported.
+- **Account has 2FA enabled** — The setup/reconfigure flow shows an extra "Verification code" step after your Panasonic ID and password. Enter the current one-time code from your authenticator app to continue.
 - **Authentication fails repeatedly** — Try resetting your MFA by logging in and out of the Panasonic Comfort Cloud app, then try again.
 - **Session expired** — The integration will notify you when authentication expires. Use the reconfigure option from the integration settings to re-authenticate.
 

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 import voluptuous as vol
+from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from aio_panasonic_comfort_cloud import ApiClient, MFARequiredError
 
 from .const import (
     CONF_DEVICE_FETCH_INTERVAL,
@@ -25,12 +30,22 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Transient form field for the one-time 2FA/MFA code — never persisted.
+CONF_OTP_CODE = "otp_code"
+
 
 class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 3
     MINOR_VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        # Credentials awaiting a 2FA/MFA code, stashed between the initial
+        # step and the "otp" step — never persisted.
+        self._pending_input: dict[str, Any] | None = None
+        self._pending_origin: str | None = None
 
     @staticmethod
     @callback
@@ -43,35 +58,151 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Handle a user initiated config flow."""
         if user_input is None:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema({
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
-                    vol.Optional(
-                        CONF_ENABLE_DAILY_ENERGY_SENSOR,
-                        default=DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
-                    ): bool,
-                    vol.Optional(
-                        CONF_FORCE_ENABLE_NANOE,
-                        default=DEFAULT_FORCE_ENABLE_NANOE,
-                    ): bool,
-                    vol.Optional(
-                        CONF_USE_PANASONIC_PRESET_NAMES,
-                        default=DEFAULT_USE_PANASONIC_PRESET_NAMES,
-                    ): bool,
-                    vol.Optional(
-                        CONF_DEVICE_FETCH_INTERVAL,
-                        default=DEFAULT_DEVICE_FETCH_INTERVAL,
-                    ): vol.All(vol.Coerce(int), vol.Range(min=5, max=300)),
-                    vol.Optional(
-                        CONF_ENERGY_FETCH_INTERVAL,
-                        default=DEFAULT_ENERGY_FETCH_INTERVAL,
-                    ): vol.All(vol.Coerce(int), vol.Range(min=10, max=600)),
-                }),
-            )
+            return self._show_user_form()
 
+        return await self._async_handle_login(user_input, "user")
+
+    async def async_step_otp(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle the 2FA/MFA one-time code step.
+
+        Only reached when the account actually requires a code — a rare
+        event that most users will never see.
+        """
+        if user_input is None:
+            return self._show_otp_form()
+
+        assert self._pending_input is not None
+        assert self._pending_origin is not None
+        merged_input = {**self._pending_input, CONF_OTP_CODE: user_input[CONF_OTP_CODE]}
+        return await self._async_handle_login(merged_input, self._pending_origin)
+
+    async def _async_handle_login(
+        self, user_input: dict[str, Any], origin: str
+    ) -> config_entries.ConfigFlowResult:
+        """Validate credentials, transparently handling a 2FA challenge.
+
+        `origin` is the step ("user" or "reconfigure") to fall back to if
+        validation fails outright, so errors are shown on the form the user
+        was actually filling in.
+        """
+        otp_code = user_input.get(CONF_OTP_CODE)
+        try:
+            errors = await self._async_try_login(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD], otp_code
+            )
+        except MFARequiredError:
+            _LOGGER.debug("Account requires a 2FA code, asking the user for one")
+            self._pending_input = {
+                key: value for key, value in user_input.items() if key != CONF_OTP_CODE
+            }
+            self._pending_origin = origin
+            return self._show_otp_form()
+
+        if errors:
+            # If a code was part of this attempt, the credentials already
+            # passed and it was the code itself that was rejected — keep the
+            # user on the OTP form rather than sending them back to the start.
+            if otp_code is not None:
+                return self._show_otp_form(errors)
+            if origin == "user":
+                return self._show_user_form(errors)
+            return self._show_reconfigure_form(errors)
+
+        self._pending_input = None
+        self._pending_origin = None
         return await self._async_create_entry(user_input)
+
+    async def _async_try_login(
+        self, username: str, password: str, otp_code: str | None = None
+    ) -> dict[str, str]:
+        """Attempt to authenticate and fetch the account's devices.
+
+        Returns a dict of form errors (empty on success). Raises
+        MFARequiredError if the account needs a 2FA code that wasn't
+        supplied — the caller is expected to prompt for one and retry.
+        """
+        client = async_get_clientsession(self.hass)
+        api = ApiClient(username, password, client)
+        errors: dict[str, str] = {}
+        try:
+            await api.start_session(otp_code)
+            devices = api.get_devices()
+
+            if not devices and not api.has_unknown_devices:
+                errors["base"] = "no_devices"
+        except MFARequiredError:
+            raise
+        except asyncio.TimeoutError:
+            _LOGGER.exception("TimeoutError")
+            errors["base"] = "device_timeout"
+        except ClientError:
+            _LOGGER.exception("ClientError")
+            errors["base"] = "device_fail"
+        except Exception as ex:  # pylint: disable=broad-except
+            err_msg = str(ex)
+            if "invalid_user_password" in err_msg:
+                errors["base"] = "invalid_user_password"
+            elif otp_code is not None and "otp" in err_msg.lower():
+                errors["base"] = "invalid_otp"
+            else:
+                _LOGGER.exception("Unexpected error validating credentials")
+                errors["base"] = "device_fail"
+        return errors
+
+    def _show_user_form(
+        self, errors: dict[str, str] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+                vol.Optional(
+                    CONF_ENABLE_DAILY_ENERGY_SENSOR,
+                    default=DEFAULT_ENABLE_DAILY_ENERGY_SENSOR,
+                ): bool,
+                vol.Optional(
+                    CONF_FORCE_ENABLE_NANOE,
+                    default=DEFAULT_FORCE_ENABLE_NANOE,
+                ): bool,
+                vol.Optional(
+                    CONF_USE_PANASONIC_PRESET_NAMES,
+                    default=DEFAULT_USE_PANASONIC_PRESET_NAMES,
+                ): bool,
+                vol.Optional(
+                    CONF_DEVICE_FETCH_INTERVAL,
+                    default=DEFAULT_DEVICE_FETCH_INTERVAL,
+                ): vol.All(vol.Coerce(int), vol.Range(min=5, max=300)),
+                vol.Optional(
+                    CONF_ENERGY_FETCH_INTERVAL,
+                    default=DEFAULT_ENERGY_FETCH_INTERVAL,
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=600)),
+            }),
+            errors=errors,
+        )
+
+    def _show_reconfigure_form(
+        self, errors: dict[str, str] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema({
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }),
+            errors=errors,
+        )
+
+    def _show_otp_form(
+        self, errors: dict[str, str] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        return self.async_show_form(
+            step_id="otp",
+            data_schema=vol.Schema({vol.Required(CONF_OTP_CODE): str}),
+            errors=errors,
+        )
 
     async def _async_create_entry(self, user_input: dict[str, Any]) -> config_entries.ConfigFlowResult:
         """Create a config entry."""
@@ -101,15 +232,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Handle a reconfiguration flow."""
         if user_input is None:
-            return self.async_show_form(
-                step_id="reconfigure",
-                data_schema=vol.Schema({
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
-                }),
-            )
+            return self._show_reconfigure_form()
 
-        return await self._async_create_entry(user_input)
+        return await self._async_handle_login(user_input, "reconfigure")
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/panasonic_cc/strings.json
+++ b/custom_components/panasonic_cc/strings.json
@@ -21,13 +21,21 @@
           "username": "Panasonic ID",
           "password": "Password"
         }
+      },
+      "otp": {
+        "title": "Two-factor authentication",
+        "description": "Your account requires a verification code. Enter the one-time code from your authenticator app.",
+        "data": {
+          "otp_code": "Verification code"
+        }
       }
     },
     "error":{
       "no_devices": "No devices found. Please check your account and CFC app and try again.",
       "device_timeout": "Timeout connecting to the API.",
       "device_fail": "Unexpected error connecting to the API.",
-      "invalid_user_password": "Invalid Panasonic ID or password."
+      "invalid_user_password": "Invalid Panasonic ID or password.",
+      "invalid_otp": "Invalid verification code. Please try again."
     },
     "abort": {
       "device_timeout": "Timeout connecting to the device.",

--- a/custom_components/panasonic_cc/translations/en.json
+++ b/custom_components/panasonic_cc/translations/en.json
@@ -21,13 +21,21 @@
           "username": "Panasonic ID",
           "password": "Password"
         }
+      },
+      "otp": {
+        "title": "Two-factor authentication",
+        "description": "Your account requires a verification code. Enter the one-time code from your authenticator app.",
+        "data": {
+          "otp_code": "Verification code"
+        }
       }
     },
     "error":{
       "no_devices": "No devices found. Please check your the account and CFC app and try again.",
       "device_timeout": "Timeout connecting to the API.",
       "device_fail": "Unexpected error connecting to the API.",
-      "invalid_user_password": "Invalid Panasonic ID or password."
+      "invalid_user_password": "Invalid Panasonic ID or password.",
+      "invalid_otp": "Invalid verification code. Please try again."
     },
     "abort": {
       "device_timeout": "Timeout connecting to the device.",


### PR DESCRIPTION
When a Panasonic account requires two-factor authentication, the setup and reconfigure flows now show an additional "Verification code" step asking for the one-time code from the user's authenticator app.

- Add `async_step_otp` step that prompts for a verification code
- Refactor login into `_async_handle_login` / `_async_try_login` so both setup and reconfigure flows share the same MFA handling logic
- Catch `MFARequiredError` from the API and transparently redirect to the OTP form, preserving previously entered credentials
- Add `invalid_otp` error string for rejected codes
- Update README troubleshooting section to reflect the new flow