### PR TITLE
chore(deps): bump aio-panasonic-comfort-cloud to 2026.8.5 and simplify device checks

### DIFF
--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -136,9 +136,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Dismiss any stale auth expired notification on successful setup
     async_dismiss(hass, NOTIFICATION_AUTH_EXPIRED)
 
-    devices = api.get_devices()
-    
-    if not devices and not api.has_unknown_devices and not api.has_aquarea_devices and not api.has_hws_devices:
+    if not api.has_devices:
         _LOGGER.error("Could not find any Panasonic Comfort Cloud Devices")
         return False
 

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -130,9 +130,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         try:
             await api.start_session(otp_code)
-            devices = api.get_devices()
 
-            if not devices and not api.has_unknown_devices:
+            if not api.has_devices:
                 errors["base"] = "no_devices"
         except MFARequiredError:
             raise

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sockless-coding/panasonic_cc/issues",
   "requirements": [
-    "aio-panasonic-comfort-cloud==2026.8.4"
+    "aio-panasonic-comfort-cloud==2026.8.5"
   ],
   "quality_scale": "silver",
   "version": "2026.8.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp
-aio-panasonic-comfort-cloud==2026.8.4
+aio-panasonic-comfort-cloud==2026.8.5


### PR DESCRIPTION
Update aio-panasonic-comfort-cloud dependency from 2026.8.4 to 2026.8.5. Leverage the new `api.has_devices` property to replace manual `get_devices()` calls with a simpler boolean check in both setup and config flow, reducing unnecessary device list retrieval.