### PR TITLE
refactor(aquarea): use unified set_aquarea_operation_state API

### DIFF
--- a/custom_components/panasonic_cc/aquarea/climate.py
+++ b/custom_components/panasonic_cc/aquarea/climate.py
@@ -206,8 +206,10 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the climate entity's zone on."""
-        await self.coordinator.api_client.set_aquarea_zone_operation_status(
-            self.coordinator.info, self.entity_description.zone_id, AquareaOperationStatus.On
+        await self.coordinator.api_client.set_aquarea_operation_state(
+            self.coordinator.device,
+            zone_id=self.entity_description.zone_id,
+            zone_status=AquareaOperationStatus.On,
         )
         params = self.coordinator.device.parameters
         zone = params.get_zone(self.entity_description.zone_id)
@@ -222,8 +224,10 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
 
     async def async_turn_off(self) -> None:
         """Turn the climate entity's zone off."""
-        await self.coordinator.api_client.set_aquarea_zone_operation_status(
-            self.coordinator.info, self.entity_description.zone_id, AquareaOperationStatus.Off
+        await self.coordinator.api_client.set_aquarea_operation_state(
+            self.coordinator.device,
+            zone_id=self.entity_description.zone_id,
+            zone_status=AquareaOperationStatus.Off,
         )
         self._attr_hvac_mode = HVACMode.OFF
         self.async_write_ha_state()
@@ -235,11 +239,11 @@ class AquareaClimateEntity(AquareaDataEntity, ClimateEntity):
             await self.async_turn_off()
             return
         operation_mode = convert_hvac_mode_to_aquarea_operation_mode(hvac_mode)
-        await self.coordinator.api_client.set_aquarea_operation_mode(
-            self.coordinator.info, operation_mode
-        )
-        await self.coordinator.api_client.set_aquarea_zone_operation_status(
-            self.coordinator.info, self.entity_description.zone_id, AquareaOperationStatus.On
+        await self.coordinator.api_client.set_aquarea_operation_state(
+            self.coordinator.device,
+            mode=operation_mode,
+            zone_id=self.entity_description.zone_id,
+            zone_status=AquareaOperationStatus.On,
         )
         self._attr_hvac_mode = hvac_mode
         self.async_write_ha_state()

--- a/custom_components/panasonic_cc/aquarea/water_heater.py
+++ b/custom_components/panasonic_cc/aquarea/water_heater.py
@@ -103,10 +103,10 @@ class AquareaWaterHeater(AquareaDataEntity, WaterHeaterEntity):
         if self.coordinator.device.parameters.tank is None:
             return
         if operation_mode == STATE_HEAT_PUMP:
-            await self.coordinator.api_client.set_aquarea_tank_operation_status(
-                self.coordinator.info, AquareaOperationStatus.On
+            await self.coordinator.api_client.set_aquarea_operation_state(
+                self.coordinator.device, tank_status=AquareaOperationStatus.On
             )
         elif operation_mode == STATE_OFF:
-            await self.coordinator.api_client.set_aquarea_tank_operation_status(
-                self.coordinator.info, AquareaOperationStatus.Off
+            await self.coordinator.api_client.set_aquarea_operation_state(
+                self.coordinator.device, tank_status=AquareaOperationStatus.Off
             )

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -13,8 +13,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sockless-coding/panasonic_cc/issues",
   "requirements": [
-    "aio-panasonic-comfort-cloud==2026.8.5"
+    "aio-panasonic-comfort-cloud==2026.8.6"
   ],
   "quality_scale": "silver",
-  "version": "2026.8.3"
+  "version": "2026.8.4"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp
-aio-panasonic-comfort-cloud==2026.8.5
+aio-panasonic-comfort-cloud==2026.8.6


### PR DESCRIPTION
Replace separate calls to set_aquarea_zone_operation_status, set_aquarea_tank_operation_status, and set_aquarea_operation_mode with the new unified set_aquarea_operation_state method. This also switches from coordinator.info to coordinator.device as the device reference.

- climate: consolidate zone on/off and hvac mode changes into single call
- water_heater: use set_aquarea_operation_state for tank status control

Bump aio-panasonic-comfort-cloud to 2026.8.6 and version to 2026.8.4.