### PR TITLE
feat: handle updated Panasonic account agreements in config flow

### DIFF
--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 
 from aio_panasonic_comfort_cloud import ApiClient
+from aio_panasonic_comfort_cloud.exceptions import AgreementNotAcceptedError
 from homeassistant.components.persistent_notification import async_dismiss
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -123,6 +124,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await api.start_session()
+    except AgreementNotAcceptedError as err:
+        _LOGGER.error(
+            "Panasonic has updated its account agreements and they need to be "
+            "re-accepted. Please re-authenticate the integration to review and accept them."
+        )
+        raise ConfigEntryAuthFailed("Panasonic account agreements need to be accepted") from err
     except Exception as err:
         error_msg = str(err).lower()
         if any(kw in error_msg for kw in ["401", "unauthorized", "authentication", "token", "expired"]):

--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Mapping
 
 import voluptuous as vol
 from aiohttp import ClientError
@@ -12,6 +12,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from aio_panasonic_comfort_cloud import ApiClient, MFARequiredError
+from aio_panasonic_comfort_cloud.exceptions import AgreementNotAcceptedError
 
 from .const import (
     CONF_AUTO_POWER_ON,
@@ -34,6 +35,8 @@ _LOGGER = logging.getLogger(__name__)
 
 # Transient form field for the one-time 2FA/MFA code — never persisted.
 CONF_OTP_CODE = "otp_code"
+# Transient form field for accepting updated Panasonic account agreements.
+CONF_ACCEPT_AGREEMENTS = "accept_agreements"
 
 
 class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -48,6 +51,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # step and the "otp" step — never persisted.
         self._pending_input: dict[str, Any] | None = None
         self._pending_origin: str | None = None
+        # The authenticated (but not yet group-listed) client and the
+        # agreement documents it's blocked on, stashed between the initial
+        # step and the "agreements" step.
+        self._pending_api: ApiClient | None = None
+        self._pending_agreements: list[dict[str, Any]] | None = None
 
     @staticmethod
     @callback
@@ -80,14 +88,49 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         merged_input = {**self._pending_input, CONF_OTP_CODE: user_input[CONF_OTP_CODE]}
         return await self._async_handle_login(merged_input, self._pending_origin)
 
+    async def async_step_agreements(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Show pending Panasonic account agreements and record acceptance.
+
+        Only reached when Panasonic has updated its terms/privacy policy
+        and the account needs to (re-)accept them before it can be used.
+        """
+        if user_input is None:
+            return await self._show_agreements_form()
+
+        if not user_input.get(CONF_ACCEPT_AGREEMENTS):
+            return await self._show_agreements_form({"base": "agreements_not_accepted"})
+
+        assert self._pending_api is not None
+        assert self._pending_agreements is not None
+        assert self._pending_input is not None
+        assert self._pending_origin is not None
+
+        try:
+            await self._pending_api.accept_agreements([
+                {"type": doc["type"], "version": doc["version"]}
+                for doc in self._pending_agreements
+            ])
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Failed to accept Panasonic account agreements")
+            return await self._show_agreements_form({"base": "device_fail"})
+
+        pending_input = self._pending_input
+        origin = self._pending_origin
+        self._pending_api = None
+        self._pending_agreements = None
+        return await self._async_handle_login(pending_input, origin)
+
     async def _async_handle_login(
         self, user_input: dict[str, Any], origin: str
     ) -> config_entries.ConfigFlowResult:
-        """Validate credentials, transparently handling a 2FA challenge.
+        """Validate credentials, transparently handling a 2FA challenge or
+        pending account agreements.
 
-        `origin` is the step ("user" or "reconfigure") to fall back to if
-        validation fails outright, so errors are shown on the form the user
-        was actually filling in.
+        `origin` is the step ("user", "reconfigure" or "reauth_confirm") to
+        fall back to if validation fails outright, so errors are shown on
+        the form the user was actually filling in.
         """
         otp_code = user_input.get(CONF_OTP_CODE)
         try:
@@ -101,6 +144,13 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
             self._pending_origin = origin
             return self._show_otp_form()
+        except AgreementNotAcceptedError:
+            _LOGGER.debug("Account has updated agreements pending acceptance")
+            self._pending_input = {
+                key: value for key, value in user_input.items() if key != CONF_OTP_CODE
+            }
+            self._pending_origin = origin
+            return await self._show_agreements_form()
 
         if errors:
             # If a code was part of this attempt, the credentials already
@@ -110,10 +160,22 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self._show_otp_form(errors)
             if origin == "user":
                 return self._show_user_form(errors)
+            if origin == "reauth_confirm":
+                return self._show_reauth_confirm_form(errors)
             return self._show_reconfigure_form(errors)
 
         self._pending_input = None
         self._pending_origin = None
+        if origin == "reauth_confirm":
+            reauth_entry = self._get_reauth_entry()
+            return self.async_update_reload_and_abort(
+                reauth_entry,
+                data={
+                    **reauth_entry.data,
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                },
+            )
         return await self._async_create_entry(user_input)
 
     async def _async_try_login(
@@ -123,7 +185,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         Returns a dict of form errors (empty on success). Raises
         MFARequiredError if the account needs a 2FA code that wasn't
-        supplied — the caller is expected to prompt for one and retry.
+        supplied, or AgreementNotAcceptedError if Panasonic requires
+        acceptance of updated agreements — the caller is expected to
+        prompt for the missing input and retry.
         """
         client = async_get_clientsession(self.hass)
         api = ApiClient(username, password, client)
@@ -134,6 +198,12 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if not api.has_devices:
                 errors["base"] = "no_devices"
         except MFARequiredError:
+            raise
+        except AgreementNotAcceptedError:
+            # Login itself succeeded — only the group listing was blocked —
+            # so this same authenticated client can accept the agreements
+            # and be reused to retry without logging in again.
+            self._pending_api = api
             raise
         except asyncio.TimeoutError:
             _LOGGER.exception("TimeoutError")
@@ -209,6 +279,68 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    def _show_reauth_confirm_form(
+        self, errors: dict[str, str] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            description_placeholders={"username": self._get_reauth_entry().data[CONF_USERNAME]},
+            errors=errors,
+        )
+
+    async def _show_agreements_form(
+        self, errors: dict[str, str] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        assert self._pending_api is not None
+        if self._pending_agreements is None:
+            try:
+                self._pending_agreements = await self._async_fetch_pending_agreements(
+                    self._pending_api
+                )
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Failed to fetch pending Panasonic account agreements")
+                origin = self._pending_origin
+                self._pending_api = None
+                self._pending_agreements = None
+                self._pending_input = None
+                self._pending_origin = None
+                if origin == "reauth_confirm":
+                    return self._show_reauth_confirm_form({"base": "device_fail"})
+                if origin == "reconfigure":
+                    return self._show_reconfigure_form({"base": "device_fail"})
+                return self._show_user_form({"base": "device_fail"})
+
+        agreements_text = "\n\n---\n\n".join(
+            doc.get("content") or f"Agreement type {doc['type']} (version {doc['version']})"
+            for doc in self._pending_agreements
+        )
+        return self.async_show_form(
+            step_id="agreements",
+            data_schema=vol.Schema({vol.Required(CONF_ACCEPT_AGREEMENTS, default=False): bool}),
+            description_placeholders={"agreements": agreements_text},
+            errors=errors,
+        )
+
+    @staticmethod
+    async def _async_fetch_pending_agreements(api: ApiClient) -> list[dict[str, Any]]:
+        """Return the agreement documents the account hasn't accepted yet."""
+        documents = await api.get_agreement_documents()
+        accepted = await api.get_agreement_status()
+        accepted_versions = {item.get("type"): item.get("version") for item in accepted}
+
+        pending: list[dict[str, Any]] = []
+        for document in documents:
+            try:
+                doc_type = int(document.get("type"))
+            except (TypeError, ValueError):
+                continue
+            version = document.get("version")
+            if accepted_versions.get(doc_type) == version:
+                continue
+            pending.append({**document, "type": doc_type})
+        return pending
+
     async def _async_create_entry(self, user_input: dict[str, Any]) -> config_entries.ConfigFlowResult:
         """Create a config entry."""
         # Validate no duplicate entries
@@ -241,6 +373,27 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self._show_reconfigure_form()
 
         return await self._async_handle_login(user_input, "reconfigure")
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> config_entries.ConfigFlowResult:
+        """Handle re-authentication, e.g. triggered by pending agreements
+        discovered while the integration was running."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Confirm re-authentication with the account's current password."""
+        if user_input is None:
+            return self._show_reauth_confirm_form()
+
+        reauth_entry = self._get_reauth_entry()
+        merged_input = {
+            CONF_USERNAME: reauth_entry.data[CONF_USERNAME],
+            CONF_PASSWORD: user_input[CONF_PASSWORD],
+        }
+        return await self._async_handle_login(merged_input, "reauth_confirm")
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/panasonic_cc/strings.json
+++ b/custom_components/panasonic_cc/strings.json
@@ -29,6 +29,20 @@
         "data": {
           "otp_code": "Verification code"
         }
+      },
+      "agreements": {
+        "title": "Updated Panasonic agreements",
+        "description": "Panasonic has updated its terms and/or policies and requires you to accept them before continuing:\n\n{agreements}",
+        "data": {
+          "accept_agreements": "I have read and accept the agreements above"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Panasonic Comfort Cloud",
+        "description": "Enter the current password for {username} to re-authenticate.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error":{
@@ -36,7 +50,8 @@
       "device_timeout": "Timeout connecting to the API.",
       "device_fail": "Unexpected error connecting to the API.",
       "invalid_user_password": "Invalid Panasonic ID or password.",
-      "invalid_otp": "Invalid verification code. Please try again."
+      "invalid_otp": "Invalid verification code. Please try again.",
+      "agreements_not_accepted": "You must accept the agreements to continue."
     },
     "abort": {
       "device_timeout": "Timeout connecting to the device.",

--- a/custom_components/panasonic_cc/translations/en.json
+++ b/custom_components/panasonic_cc/translations/en.json
@@ -29,6 +29,20 @@
         "data": {
           "otp_code": "Verification code"
         }
+      },
+      "agreements": {
+        "title": "Updated Panasonic agreements",
+        "description": "Panasonic has updated its terms and/or policies and requires you to accept them before continuing:\n\n{agreements}",
+        "data": {
+          "accept_agreements": "I have read and accept the agreements above"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Panasonic Comfort Cloud",
+        "description": "Enter the current password for {username} to re-authenticate.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error":{
@@ -36,7 +50,8 @@
       "device_timeout": "Timeout connecting to the API.",
       "device_fail": "Unexpected error connecting to the API.",
       "invalid_user_password": "Invalid Panasonic ID or password.",
-      "invalid_otp": "Invalid verification code. Please try again."
+      "invalid_otp": "Invalid verification code. Please try again.",
+      "agreements_not_accepted": "You must accept the agreements to continue."
     },
     "abort": {
       "device_timeout": "Timeout connecting to the device.",


### PR DESCRIPTION
When Panasonic updates its terms or policies, the API blocks accounts that haven't accepted the new agreements. This change adds support for detecting and resolving that situation seamlessly:

- Catch AgreementNotAcceptedError during session start and raise ConfigEntryAuthFailed to trigger a re-authentication flow.
- Add "agreements" config-flow step that fetches pending agreement documents, displays them to the user, and records acceptance via api.accept_agreements().
- Add async_step_reauth / async_step_reauth_confirm so existing entries can be re-authenticated when agreements are discovered at runtime.
- Update _async_try_login to stash the authenticated ApiClient between steps so it can accept agreements without requiring a second login.
- Add corresponding UI strings for the agreements form, reauth confirm form, and "agreements_not_accepted" error message.