### PR TITLE
fix: force fresh login on reauth instead of reusing cached session

### DIFF
--- a/custom_components/panasonic_cc/config_flow.py
+++ b/custom_components/panasonic_cc/config_flow.py
@@ -135,7 +135,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         otp_code = user_input.get(CONF_OTP_CODE)
         try:
             errors = await self._async_try_login(
-                user_input[CONF_USERNAME], user_input[CONF_PASSWORD], otp_code
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD], otp_code, origin
             )
         except MFARequiredError:
             _LOGGER.debug("Account requires a 2FA code, asking the user for one")
@@ -179,7 +179,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._async_create_entry(user_input)
 
     async def _async_try_login(
-        self, username: str, password: str, otp_code: str | None = None
+        self, username: str, password: str, otp_code: str | None = None, origin: str = "user"
     ) -> dict[str, str]:
         """Attempt to authenticate and fetch the account's devices.
 
@@ -188,12 +188,21 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         supplied, or AgreementNotAcceptedError if Panasonic requires
         acceptance of updated agreements — the caller is expected to
         prompt for the missing input and retry.
+
+        For a "reauth_confirm" origin this forces a completely fresh login
+        via reauthenticate() rather than start_session(), which would
+        otherwise silently keep reusing a cached (and possibly stale/stuck)
+        session from the settings file instead of the credentials the user
+        just entered.
         """
         client = async_get_clientsession(self.hass)
         api = ApiClient(username, password, client)
         errors: dict[str, str] = {}
         try:
-            await api.start_session(otp_code)
+            if origin == "reauth_confirm":
+                await api.reauthenticate(otp_code)
+            else:
+                await api.start_session(otp_code)
 
             if not api.has_devices:
                 errors["base"] = "no_devices"

--- a/custom_components/panasonic_cc/manifest.json
+++ b/custom_components/panasonic_cc/manifest.json
@@ -13,8 +13,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sockless-coding/panasonic_cc/issues",
   "requirements": [
-    "aio-panasonic-comfort-cloud==2026.8.7"
+    "aio-panasonic-comfort-cloud==2026.8.8"
   ],
   "quality_scale": "silver",
-  "version": "2026.8.5"
+  "version": "2026.8.6"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp
-aio-panasonic-comfort-cloud==2026.8.7
+aio-panasonic-comfort-cloud==2026.8.8


### PR DESCRIPTION
When the user re-enters credentials during reauth, _async_try_login was still calling start_session(), which silently kept reusing the cached (possibly stale) session from the settings file. Pass the flow origin through and call reauthenticate() for the "reauth_confirm" origin so the entered credentials are actually used.

Also bump aio-panasonic-comfort-cloud to 2026.8.8 and release 2026.8.6.