### PR TITLE
fix(panasonic): pass auto_power_on through to the change request builder

### DIFF
--- a/custom_components/panasonic_cc/panasonic/coordinator.py
+++ b/custom_components/panasonic_cc/panasonic/coordinator.py
@@ -136,7 +136,7 @@ class PanasonicDeviceCoordinator(DataUpdateCoordinator[int]):
 
     def get_change_request_builder(self) -> ChangeRequestBuilder:
         """Get a change request builder for the current device."""
-        return ChangeRequestBuilder(self.device)
+        return self._api_client.new_change_request(self.device)
 
     async def async_apply_changes(self, request_builder: ChangeRequestBuilder) -> None:
         """Apply changes to the device."""


### PR DESCRIPTION
`2026.8.7` added the `auto_power_on` option (#495), but setting it to `false` has no effect — a settings write to a powered-off unit still turns it on.

`panasonic/__init__.py` passes the option to the client correctly. `PanasonicDeviceCoordinator.get_change_request_builder` then constructs its own builder without it:

```python
def get_change_request_builder(self) -> ChangeRequestBuilder:
    return ChangeRequestBuilder(self.device)
```

`ChangeRequestBuilder.__init__` defaults to `auto_power_on=True`, so `_ensure_powered_on()` adds `operate: On` to the request. That also defeats the other half of the design: `set_device_raw()` buffers a change for an off device *unless* the request is turning it on — and this one always is.

`ApiClient` already exposes the right factory: `new_change_request(device)`, documented as *"Create a ChangeRequestBuilder wired to this client's auto_power_on setting"*.

```diff
-return ChangeRequestBuilder(self.device)
+return self._api_client.new_change_request(self.device)
```

### Tested

On a real **CS-HZ25XKE**, integration `2026.8.7`, with `auto_power_on: false` set on the entry — not in the devcontainer:

| step | before | after |
| --- | --- | --- |
| unit commanded off | off | off |
| setpoint written while off | **heat** — woken | **off** — change buffered |
| explicit `hvac_mode: heat` | heat | heat, and the buffered setpoint applied |

The third row is the one worth reviewing: `set_hvac_mode` uses `_force_powered_on()`, so an explicit mode command still powers the unit on as intended. Only the implicit wake-on-settings-change is suppressed, which is what the option is for.

### Notes

- No requirements change: `new_change_request` is in `aio-panasonic-comfort-cloud==2026.8.9`, already pinned by the manifest.
- The `ChangeRequestBuilder` import stays in use as a type annotation.
- `coordinator.py` does not currently pass `black --check`, but that predates this change and black leaves this line alone, so the file is left otherwise untouched rather than reformatted in a one-line fix.

This may also be relevant to #378 and #474, which describe a unit coming back on after being turned off — the comment on #378 identifies a setpoint write as the trigger. I haven't reproduced either reporter's setup, and neither is on a version carrying this option, so I'm not claiming to close them.
